### PR TITLE
validator runs using docker file with correct download parameters

### DIFF
--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+
+# Build arguments for release configuration
+ARG RELEASE_BASE_URL=https://github.com/paritytech/polkajam-releases/releases/download/
+ARG RELEASE_VERSION=nightly-2025-11-06
+ARG RELEASE_ARCH=linux-x86_64
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download and install polkajam
+ARG RELEASE_FILE=polkajam-${RELEASE_VERSION}-${RELEASE_ARCH}
+
+RUN curl -L ${RELEASE_BASE_URL}${RELEASE_VERSION}/polkajam-${RELEASE_VERSION}-${RELEASE_ARCH}.tgz -o /tmp/polkajam.tgz
+
+RUN tar -xzf /tmp/polkajam.tgz -C /tmp/
+
+RUN mv /tmp/polkajam-${RELEASE_VERSION}-${RELEASE_ARCH}/polkajam /usr/local/bin/polkajam && \
+    chmod +x /usr/local/bin/polkajam
+
+RUN rm -rf /tmp/polkajam.tgz /tmp/polkajam-${RELEASE_VERSION}-${RELEASE_ARCH}
+
+# Set working directory
+WORKDIR /data
+
+# Expose default ports (if needed)
+# EXPOSE 30333 9944 9615
+
+# Default command (can be overridden in docker-compose)
+ENTRYPOINT ["/usr/local/bin/polkajam"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ git clone https://github.com/your-org/tart-backend.git
 cd tart-backend
 
 # Start backend + PostgreSQL
-docker-compose up -d
-
+docker compose up -d
+# OR start with a single validator
+docker compose --profile with-validator up
 # View logs
-docker-compose logs -f tart-backend
+docker compose logs -f tart-backend
 
 # API endpoint at http://localhost:8080
 # Telemetry endpoint at tcp://localhost:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL database
   postgres:
@@ -68,28 +66,28 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3
 
   # Optional: JAM validator node
   jam-validator-0:
-    image: polkajam:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.validator
+      args:
+        - RELEASE_BASE_URL=${RELEASE_BASE_URL:-https://github.com/paritytech/polkajam-releases/releases/download/}
+        - RELEASE_VERSION=${RELEASE_VERSION:-nightly-2025-11-06}
+        - RELEASE_ARCH=${RELEASE_ARCH:-linux-aarch64}
     container_name: jam-validator-0
-    command: >
-      --chain dev
-      run
-      --telemetry tart-backend:9000
-      --dev-validator 0
-      --temp
+    command: ["--chain", "dev", "run", "--telemetry", "tart-backend:9000", "--dev-validator", "0", "--temp"]
     depends_on:
       tart-backend:
         condition: service_healthy
     restart: unless-stopped
     profiles:
       - with-validator
-
 volumes:
   postgres-data:
     driver: local


### PR DESCRIPTION
This PR adds a Dockerfile specific to build and run polkajam node, downloading from releases, since the docker image in previous code doesn't exist. Also points to the correct api health check. 

In future, teams could follow the same idea and add their own "dockerfile" and change the docker-compose configuration, adding other nodes from different implementations, all connected to tart.