### PR TITLE
events streaming improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4123,6 +4123,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "tower 0.4.13",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4118,6 +4118,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "socket2 0.5.10",
  "sqlx",
  "thiserror 1.0.69",
  "tikv-jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dashmap = "6.0"
 futures = "0.3"
 hex = "0.4"
+tokio-stream = { version = "0.1", features = ["sync"] }
 rand = "0.8"
 
 # Networking
@@ -113,8 +114,9 @@ codegen-units = 256
 
 [profile.release]
 opt-level = 3
-lto = "fat"
-codegen-units = 1
+# lto = "fat"
+lto = false
+codegen-units = 16
 panic = "abort"
 debug = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,12 @@ tikv-jemallocator = { version = "0.6", optional = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+# CLI argument parsing
+clap = { version = "4.4", features = ["derive", "env"] }
+
 # Dashboard dependencies (feature-gated to avoid bloating main binary)
 ratatui = { version = "0.26", optional = true }
 crossterm = { version = "0.27", optional = true }
-clap = { version = "4.4", features = ["derive", "env"], optional = true }
 reqwest = { version = "0.11", features = ["json", "blocking"], optional = true }
 
 # Benchmark dependencies (feature-gated)
@@ -91,7 +93,7 @@ url = "2.5"
 [features]
 default = ["jemalloc"]
 jemalloc = ["tikv-jemallocator"]
-dashboard = ["ratatui", "crossterm", "clap", "reqwest"]
+dashboard = ["ratatui", "crossterm", "reqwest"]
 bench = ["reqwest", "hdrhistogram", "tokio-tungstenite"]
 profiling = ["dhat"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ futures = "0.3"
 hex = "0.4"
 rand = "0.8"
 
+# Networking
+socket2 = { version = "0.5", features = ["all"] }
+
 # Performance optimizations
 parking_lot = "0.12"
 metrics = "0.23"
@@ -113,7 +116,7 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 panic = "abort"
-strip = "symbols"
+debug = true
 
 [profile.profiling]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -479,12 +479,31 @@ Connect to receive live events as they arrive from nodes.
   "filter": { "type": "All" }
 }
 
-// Subscribe to specific node
+// Subscribe to specific nodes
 {
   "type": "Subscribe",
   "filter": {
-    "type": "Node",
-    "node_id": "a1b2c3d4..."
+    "type": "Nodes",
+    "node_ids": ["a1b2c3d4..."]
+  }
+}
+
+// Subscribe to multiple nodes
+{
+  "type": "Subscribe",
+  "filter": {
+    "type": "Nodes",
+    "node_ids": ["a1b2c3d4...", "e5f6a7b8..."]
+  }
+}
+
+// Subscribe to all node channels (wildcard) — uses per-node StreamMap internally,
+// intended for performance evaluation of the StreamMap implementation.
+{
+  "type": "Subscribe",
+  "filter": {
+    "type": "Nodes",
+    "node_ids": ["*"]
   }
 }
 
@@ -520,14 +539,13 @@ Connect to receive live events as they arrive from nodes.
   "timestamp": "2025-10-28T14:30:00Z"
 }
 
-// New event
+// New event (single)
 {
   "type": "event",
   "data": {
     "id": 12345,
     "node_id": "a1b2c3d4...",
     "event_type": 11,
-    "latency_ms": 2,
     "event": {
       "BestBlockChanged": {
         "slot": 1234,
@@ -535,6 +553,16 @@ Connect to receive live events as they arrive from nodes.
       }
     }
   },
+  "timestamp": "2025-10-28T14:30:00Z"
+}
+
+// Batched events (up to 100 per frame, opportunistic)
+{
+  "type": "batch",
+  "data": [
+    { "id": 12345, "node_id": "a1b2c3d4...", "event_type": 11, "event": { /* ... */ } },
+    { "id": 12346, "node_id": "a1b2c3d4...", "event_type": 12, "event": { /* ... */ } }
+  ],
   "timestamp": "2025-10-28T14:30:00Z"
 }
 
@@ -814,8 +842,8 @@ class TartWebSocket {
     this.send({ type: "Subscribe", filter });
   }
 
-  subscribeToNode(nodeId) {
-    this.subscribe({ type: "Node", node_id: nodeId });
+  subscribeToNodes(nodeIds) {
+    this.subscribe({ type: "Nodes", node_ids: nodeIds });
   }
 
   getRecentEvents(limit = 100) {
@@ -857,8 +885,8 @@ client.on("stats", (data) => {
   console.log("Stats:", data);
 });
 
-// Subscribe to specific node
-client.subscribeToNode("a1b2c3d4...");
+// Subscribe to specific nodes
+client.subscribeToNodes(["a1b2c3d4...", "e5f6a7b8..."]);
 
 // Keep-alive
 setInterval(() => client.ping(), 30000);

--- a/src/api.rs
+++ b/src/api.rs
@@ -1775,11 +1775,11 @@ enum WebSocketRequest {
     UnsubscribeAlerts,
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type")]
 enum SubscriptionFilter {
     All,
-    Node { node_id: String },
+    Nodes { node_ids: Vec<String> },
     EventType { event_type: u8 },
     EventTypeRange { start: u8, end: u8 },
 }
@@ -1826,6 +1826,58 @@ const WS_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// drain broadcast_lag spikes faster (observed up to 524K with batch=10).
 const WS_BATCH_SIZE: usize = 100;
 
+use crate::event_broadcaster::BroadcastEvent;
+
+/// Dual receive mode for WS event streaming.
+/// `All` uses the main broadcast channel (firehose).
+/// `Filtered` uses a StreamMap over per-node broadcast channels.
+enum EventSource {
+    All(tokio::sync::broadcast::Receiver<Arc<BroadcastEvent>>),
+    Filtered(tokio_stream::StreamMap<String, tokio_stream::wrappers::BroadcastStream<Arc<BroadcastEvent>>>),
+}
+
+impl EventSource {
+    async fn recv(&mut self) -> Result<Arc<BroadcastEvent>, tokio::sync::broadcast::error::RecvError> {
+        match self {
+            EventSource::All(rx) => rx.recv().await,
+            EventSource::Filtered(map) => {
+                use tokio_stream::StreamExt;
+                match map.next().await {
+                    Some((_key, Ok(event))) => Ok(event),
+                    Some((_key, Err(_))) => Err(tokio::sync::broadcast::error::RecvError::Lagged(0)),
+                    None => Err(tokio::sync::broadcast::error::RecvError::Closed),
+                }
+            }
+        }
+    }
+
+    fn try_recv(&mut self) -> Result<Arc<BroadcastEvent>, tokio::sync::broadcast::error::TryRecvError> {
+        match self {
+            EventSource::All(rx) => rx.try_recv(),
+            EventSource::Filtered(map) => {
+                // Poll StreamMap synchronously for batching support.
+                // Without this, a client subscribing to 512 nodes (~500K events/s)
+                // would send each event individually — as bad as the firehose.
+                use futures::Stream;
+                let waker = futures::task::noop_waker();
+                let mut cx = std::task::Context::from_waker(&waker);
+                match std::pin::Pin::new(map).poll_next(&mut cx) {
+                    std::task::Poll::Ready(Some((_key, Ok(event)))) => Ok(event),
+                    std::task::Poll::Ready(Some((_key, Err(_)))) => Err(tokio::sync::broadcast::error::TryRecvError::Lagged(0)),
+                    _ => Err(tokio::sync::broadcast::error::TryRecvError::Empty),
+                }
+            }
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            EventSource::All(rx) => rx.len(),
+            EventSource::Filtered(_) => 0,
+        }
+    }
+}
+
 async fn websocket_connection(
     mut socket: WebSocket,
     broadcaster: Arc<EventBroadcaster>,
@@ -1869,8 +1921,8 @@ async fn websocket_connection(
         return;
     }
 
-    // Default to subscribing to all events
-    let mut event_receiver = broadcaster.subscribe_all();
+    // Default to subscribing to all events via main broadcast channel
+    let mut event_source = EventSource::All(broadcaster.subscribe_all());
     let mut current_filter = SubscriptionFilter::All;
 
     // Stats update interval (5 seconds)
@@ -1895,13 +1947,11 @@ async fn websocket_connection(
     let mut debug_send_time_us = 0u64;
     let mut debug_sends_since_log = 0u64;
     let mut debug_lagged_total = 0u64;
-    let mut debug_loop_iterations = 0u64;
 
     loop {
-        debug_loop_iterations += 1;
         tokio::select! {
             // Real-time event streaming from broadcaster
-            result = event_receiver.recv() => {
+            result = event_source.recv() => {
             match result {
             Ok(event) => {
                 // Opportunistic batching: collect first event, then drain more via try_recv()
@@ -1928,7 +1978,7 @@ async fn websocket_connection(
 
                 // Drain more events without blocking
                 while batch.len() < WS_BATCH_SIZE {
-                    match event_receiver.try_recv() {
+                    match event_source.try_recv() {
                         Ok(ev) => {
                             if let Some(ref json) = ev.serialized_json {
                                 batch.push(std::sync::Arc::clone(json));
@@ -1987,18 +2037,30 @@ async fn websocket_connection(
                 if debug_last_log.elapsed() >= std::time::Duration::from_secs(2) {
                     let elapsed = debug_last_log.elapsed().as_secs_f64();
                     let avg_send_us = if debug_sends_since_log > 0 { debug_send_time_us / debug_sends_since_log } else { 0 };
+                    let filter_desc = match &current_filter {
+                        SubscriptionFilter::All => "all".to_string(),
+                        SubscriptionFilter::Nodes { node_ids } => {
+                            if node_ids.len() == 1 && node_ids[0] == "*" {
+                                "nodes(*)".to_string()
+                            } else {
+                                format!("nodes({})", node_ids.len())
+                            }
+                        }
+                        SubscriptionFilter::EventType { event_type } => format!("etype({})", event_type),
+                        SubscriptionFilter::EventTypeRange { start, end } => format!("etype({}-{})", start, end),
+                    };
                     debug!(
-                        "WS stats: {:.0} events/s, avg_send={}us, lagged_total={}, loops={}, broadcast_lag={}",
+                        "WS [{}]: {:.0} ev/s, avg_send={}us, lagged={}, lag={}, batch_avg={:.0}",
+                        filter_desc,
                         debug_events_since_log as f64 / elapsed,
                         avg_send_us,
                         debug_lagged_total,
-                        debug_loop_iterations,
-                        event_receiver.len(),
+                        event_source.len(),
+                        if debug_sends_since_log > 0 { debug_events_since_log as f64 / debug_sends_since_log as f64 } else { 0.0 },
                     );
                     debug_events_since_log = 0;
                     debug_send_time_us = 0;
                     debug_sends_since_log = 0;
-                    debug_loop_iterations = 0;
                     debug_last_log = tokio::time::Instant::now();
                 }
 
@@ -2022,23 +2084,53 @@ async fn websocket_connection(
                             match request {
                                 WebSocketRequest::Subscribe { filter } => {
                                     // Update subscription based on filter
-                                    event_receiver = match &filter {
+                                    event_source = match &filter {
                                         SubscriptionFilter::All => {
-                                            broadcaster.subscribe_all()
+                                            EventSource::All(broadcaster.subscribe_all())
                                         }
-                                        SubscriptionFilter::Node { node_id } => {
-                                            broadcaster.subscribe_node(node_id)
+                                        SubscriptionFilter::Nodes { node_ids } => {
+                                            let mut map = tokio_stream::StreamMap::new();
+                                            let subs = if node_ids.len() == 1 && node_ids[0] == "*" {
+                                                // Wildcard: subscribe to all node channels via StreamMap
+                                                broadcaster.subscribe_all_nodes()
+                                            } else {
+                                                broadcaster.subscribe_nodes(node_ids)
+                                            };
+                                            for (id, rx) in subs {
+                                                map.insert(id, tokio_stream::wrappers::BroadcastStream::new(rx));
+                                            }
+                                            EventSource::Filtered(map)
                                         }
                                         SubscriptionFilter::EventType { event_type: _ } => {
-                                            // For now, use main channel and client-side filtering
-                                            broadcaster.subscribe_all()
+                                            // Use main channel + client-side filtering
+                                            EventSource::All(broadcaster.subscribe_all())
                                         }
                                         SubscriptionFilter::EventTypeRange { start: _, end: _ } => {
-                                            // For now, use main channel and client-side filtering
-                                            broadcaster.subscribe_all()
+                                            // Use main channel + client-side filtering
+                                            EventSource::All(broadcaster.subscribe_all())
                                         }
                                     };
                                     current_filter = filter.clone();
+                                    // Reset per-subscription stats
+                                    debug_lagged_total = 0;
+                                    debug_events_since_log = 0;
+                                    debug_send_time_us = 0;
+                                    debug_sends_since_log = 0;
+                                    debug_last_log = tokio::time::Instant::now();
+
+                                    let sub_desc = match &current_filter {
+                                        SubscriptionFilter::All => "All".to_string(),
+                                        SubscriptionFilter::Nodes { node_ids } => {
+                                            if node_ids.len() == 1 && node_ids[0] == "*" {
+                                                "Nodes(* → all channels)".to_string()
+                                            } else {
+                                                format!("Nodes({})", node_ids.len())
+                                            }
+                                        }
+                                        SubscriptionFilter::EventType { event_type } => format!("EventType({})", event_type),
+                                        SubscriptionFilter::EventTypeRange { start, end } => format!("EventTypeRange({}-{})", start, end),
+                                    };
+                                    info!("WS subscribed: {}", sub_desc);
 
                                     let response = WebSocketResponse {
                                         r#type: "subscribed".to_string(),
@@ -2055,7 +2147,7 @@ async fn websocket_connection(
                                 }
                                 WebSocketRequest::Unsubscribe => {
                                     // Reset to all events
-                                    event_receiver = broadcaster.subscribe_all();
+                                    event_source = EventSource::All(broadcaster.subscribe_all());
                                     current_filter = SubscriptionFilter::All;
 
                                     let response = WebSocketResponse {
@@ -2279,8 +2371,8 @@ async fn websocket_connection(
 
     ACTIVE_WS_CONNECTIONS.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
     info!(
-        "WebSocket connection closed (received {} events)",
-        events_received
+        "WS closed: {} events received, lagged_total={}, filter={:?}",
+        events_received, debug_lagged_total, current_filter
     );
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::timeout::TimeoutLayer;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Validates that a node_id is a valid 64-character hexadecimal string (32 bytes encoded).
 fn is_valid_node_id(node_id: &str) -> bool {
@@ -1821,9 +1821,10 @@ async fn websocket_handler(
 const WS_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Max events per WS message. Opportunistic batching: after receiving one event,
-/// drain up to this many more via try_recv() (non-blocking). At batch=10,
-/// ws-synth measured 1.2M events/s vs 158K unbatched.
-const WS_BATCH_SIZE: usize = 10;
+/// drain up to this many more via try_recv() (non-blocking). At batch=100,
+/// ws-synth measured 1.6M events/s vs 158K unbatched. Larger batches help
+/// drain broadcast_lag spikes faster (observed up to 524K with batch=10).
+const WS_BATCH_SIZE: usize = 100;
 
 async fn websocket_connection(
     mut socket: WebSocket,
@@ -1986,8 +1987,8 @@ async fn websocket_connection(
                 if debug_last_log.elapsed() >= std::time::Duration::from_secs(2) {
                     let elapsed = debug_last_log.elapsed().as_secs_f64();
                     let avg_send_us = if debug_sends_since_log > 0 { debug_send_time_us / debug_sends_since_log } else { 0 };
-                    warn!(
-                        "WS debug: {:.0} events/s, avg_send={}us, lagged_total={}, loops={}, broadcast_lag={}",
+                    debug!(
+                        "WS stats: {:.0} events/s, avg_send={}us, lagged_total={}, loops={}, broadcast_lag={}",
                         debug_events_since_log as f64 / elapsed,
                         avg_send_us,
                         debug_lagged_total,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1813,7 +1813,13 @@ async fn websocket_handler(
     Ok(ws.on_upgrade(move |socket| {
         let store = Some(state.store.clone());
         let cache = Some(state.cache.clone());
-        websocket_connection(socket, state.broadcaster, state.telemetry_server, store, cache)
+        websocket_connection(
+            socket,
+            state.broadcaster,
+            state.telemetry_server,
+            store,
+            cache,
+        )
     }))
 }
 
@@ -1833,25 +1839,36 @@ use crate::event_broadcaster::BroadcastEvent;
 /// `Filtered` uses a StreamMap over per-node broadcast channels.
 enum EventSource {
     All(tokio::sync::broadcast::Receiver<Arc<BroadcastEvent>>),
-    Filtered(tokio_stream::StreamMap<String, tokio_stream::wrappers::BroadcastStream<Arc<BroadcastEvent>>>),
+    Filtered(
+        tokio_stream::StreamMap<
+            String,
+            tokio_stream::wrappers::BroadcastStream<Arc<BroadcastEvent>>,
+        >,
+    ),
 }
 
 impl EventSource {
-    async fn recv(&mut self) -> Result<Arc<BroadcastEvent>, tokio::sync::broadcast::error::RecvError> {
+    async fn recv(
+        &mut self,
+    ) -> Result<Arc<BroadcastEvent>, tokio::sync::broadcast::error::RecvError> {
         match self {
             EventSource::All(rx) => rx.recv().await,
             EventSource::Filtered(map) => {
                 use tokio_stream::StreamExt;
                 match map.next().await {
                     Some((_key, Ok(event))) => Ok(event),
-                    Some((_key, Err(_))) => Err(tokio::sync::broadcast::error::RecvError::Lagged(0)),
+                    Some((_key, Err(_))) => {
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(0))
+                    }
                     None => Err(tokio::sync::broadcast::error::RecvError::Closed),
                 }
             }
         }
     }
 
-    fn try_recv(&mut self) -> Result<Arc<BroadcastEvent>, tokio::sync::broadcast::error::TryRecvError> {
+    fn try_recv(
+        &mut self,
+    ) -> Result<Arc<BroadcastEvent>, tokio::sync::broadcast::error::TryRecvError> {
         match self {
             EventSource::All(rx) => rx.try_recv(),
             EventSource::Filtered(map) => {
@@ -1863,7 +1880,9 @@ impl EventSource {
                 let mut cx = std::task::Context::from_waker(&waker);
                 match std::pin::Pin::new(map).poll_next(&mut cx) {
                     std::task::Poll::Ready(Some((_key, Ok(event)))) => Ok(event),
-                    std::task::Poll::Ready(Some((_key, Err(_)))) => Err(tokio::sync::broadcast::error::TryRecvError::Lagged(0)),
+                    std::task::Poll::Ready(Some((_key, Err(_)))) => {
+                        Err(tokio::sync::broadcast::error::TryRecvError::Lagged(0))
+                    }
                     _ => Err(tokio::sync::broadcast::error::TryRecvError::Empty),
                 }
             }
@@ -2419,7 +2438,12 @@ async fn minimal_websocket_handler(
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
     Ok(ws.on_upgrade(move |socket| {
-        websocket_connection(socket, state.broadcaster, state.telemetry_server, None, None)
+        websocket_connection(
+            socket,
+            state.broadcaster,
+            state.telemetry_server,
+            None,
+            None,
+        )
     }))
 }
-

--- a/src/api.rs
+++ b/src/api.rs
@@ -2092,10 +2092,15 @@ async fn websocket_connection(
                                             let mut map = tokio_stream::StreamMap::new();
                                             let subs = if node_ids.len() == 1 && node_ids[0] == "*" {
                                                 // Wildcard: subscribe to all node channels via StreamMap
-                                                broadcaster.subscribe_all_nodes()
+                                                broadcaster.subscribe_all_nodes().await
                                             } else {
-                                                broadcaster.subscribe_nodes(node_ids)
+                                                broadcaster.subscribe_nodes(node_ids).await
                                             };
+                                            debug!(
+                                                "WS building StreamMap: requested={}, found={}",
+                                                if node_ids.len() == 1 && node_ids[0] == "*" { "all".to_string() } else { node_ids.len().to_string() },
+                                                subs.len(),
+                                            );
                                             for (id, rx) in subs {
                                                 map.insert(id, tokio_stream::wrappers::BroadcastStream::new(rx));
                                             }

--- a/src/api.rs
+++ b/src/api.rs
@@ -2091,7 +2091,9 @@ async fn websocket_connection(
                                         SubscriptionFilter::Nodes { node_ids } => {
                                             let mut map = tokio_stream::StreamMap::new();
                                             let subs = if node_ids.len() == 1 && node_ids[0] == "*" {
-                                                // Wildcard: subscribe to all node channels via StreamMap
+                                                // Wildcard: subscribe to all node channels via StreamMap.
+                                                // Intentionally uses StreamMap (not main channel) to benchmark
+                                                // StreamMap performance vs the firehose.
                                                 broadcaster.subscribe_all_nodes().await
                                             } else {
                                                 broadcaster.subscribe_nodes(node_ids).await

--- a/src/api.rs
+++ b/src/api.rs
@@ -1810,26 +1810,37 @@ async fn websocket_handler(
         );
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
-    Ok(ws.on_upgrade(move |socket| websocket_connection(socket, state)))
+    Ok(ws.on_upgrade(move |socket| {
+        let store = Some(state.store.clone());
+        let cache = Some(state.cache.clone());
+        websocket_connection(socket, state.broadcaster, state.telemetry_server, store, cache)
+    }))
 }
 
 /// Send timeout for WebSocket messages - prevents slow clients from blocking
 const WS_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
-async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
+async fn websocket_connection(
+    mut socket: WebSocket,
+    broadcaster: Arc<EventBroadcaster>,
+    telemetry_server: Arc<TelemetryServer>,
+    store: Option<Arc<EventStore>>,
+    cache: Option<Arc<TtlCache>>,
+) {
     ACTIVE_WS_CONNECTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     info!("WebSocket connection established");
 
     // Send initial connection confirmation with recent events
-    let recent_events = state.broadcaster.get_recent_events(Some(200));
-    let broadcaster_stats = state.broadcaster.get_stats();
+    let recent_events = broadcaster.get_recent_events(Some(200));
+    let broadcaster_stats = broadcaster.get_stats();
+    let has_db = store.is_some();
 
     let initial_state = WebSocketResponse {
         r#type: "connected".to_string(),
         data: serde_json::json!({
             "message": "Connected to TART telemetry (1024-node scale)",
             "recent_events": recent_events.len(),
-            "total_nodes": state.telemetry_server.connection_count(),
+            "total_nodes": telemetry_server.connection_count(),
             "broadcaster_stats": broadcaster_stats,
             "recent_event_samples": recent_events.iter().take(200).map(|e| {
                 serde_json::json!({
@@ -1853,7 +1864,7 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
     }
 
     // Default to subscribing to all events
-    let mut event_receiver = state.broadcaster.subscribe_all();
+    let mut event_receiver = broadcaster.subscribe_all();
     let mut current_filter = SubscriptionFilter::All;
 
     // Stats update interval (5 seconds)
@@ -1921,18 +1932,18 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
                                     // Update subscription based on filter
                                     event_receiver = match &filter {
                                         SubscriptionFilter::All => {
-                                            state.broadcaster.subscribe_all()
+                                            broadcaster.subscribe_all()
                                         }
                                         SubscriptionFilter::Node { node_id } => {
-                                            state.broadcaster.subscribe_node(node_id)
+                                            broadcaster.subscribe_node(node_id)
                                         }
                                         SubscriptionFilter::EventType { event_type: _ } => {
                                             // For now, use main channel and client-side filtering
-                                            state.broadcaster.subscribe_all()
+                                            broadcaster.subscribe_all()
                                         }
                                         SubscriptionFilter::EventTypeRange { start: _, end: _ } => {
                                             // For now, use main channel and client-side filtering
-                                            state.broadcaster.subscribe_all()
+                                            broadcaster.subscribe_all()
                                         }
                                     };
                                     current_filter = filter.clone();
@@ -1952,7 +1963,7 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
                                 }
                                 WebSocketRequest::Unsubscribe => {
                                     // Reset to all events
-                                    event_receiver = state.broadcaster.subscribe_all();
+                                    event_receiver = broadcaster.subscribe_all();
                                     current_filter = SubscriptionFilter::All;
 
                                     let response = WebSocketResponse {
@@ -1966,7 +1977,7 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
                                     }
                                 }
                                 WebSocketRequest::GetRecentEvents { limit } => {
-                                    let events = state.broadcaster.get_recent_events(limit);
+                                    let events = broadcaster.get_recent_events(limit);
 
                                     let response = WebSocketResponse {
                                         r#type: "recent_events".to_string(),
@@ -2076,14 +2087,15 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
             }
 
             // Periodic stats updates (read from cache to avoid N*DB queries for N WS clients)
-            _ = stats_interval.tick() => {
-                let stats_result = cache_or_compute(&state.cache, "stats", || async {
-                    state.store.get_stats("1 hour", "24 hours").await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+            _ = stats_interval.tick(), if has_db => {
+                let stats_result = cache_or_compute(cache.as_ref().unwrap(), "stats", || {
+                    let store = store.clone().unwrap();
+                    async move { store.get_stats("1 hour", "24 hours").await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR) }
                 }).await;
 
                 if let Ok(db_stats) = stats_result {
-                    let broadcaster_stats = state.broadcaster.get_stats();
-                    let node_ids = state.telemetry_server.get_connection_ids();
+                    let broadcaster_stats = broadcaster.get_stats();
+                    let node_ids = telemetry_server.get_connection_ids();
 
                     let response = WebSocketResponse {
                         r#type: "stats".to_string(),
@@ -2114,15 +2126,16 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
             }
 
             // Metrics channel updates (if subscribed, read from cache)
-            _ = metrics_interval.tick(), if metrics_subscribed => {
-                let metrics_result = cache_or_compute(&state.cache, "aggregated_metrics", || async {
-                    state.store.get_aggregated_metrics().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+            _ = metrics_interval.tick(), if metrics_subscribed && has_db => {
+                let metrics_result = cache_or_compute(cache.as_ref().unwrap(), "aggregated_metrics", || {
+                    let store = store.clone().unwrap();
+                    async move { store.get_aggregated_metrics().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR) }
                 }).await;
 
                 if let Ok(metrics) = metrics_result {
                     // Enrich with core status from cache (pre-warmed every 2s)
                     let mut data = (*metrics).clone();
-                    if let Some(cores) = state.cache.get("cores_status") {
+                    if let Some(cores) = cache.as_ref().unwrap().get("cores_status") {
                         data["cores"] = (*cores).clone();
                     }
 
@@ -2141,8 +2154,8 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
             }
 
             // Alerts channel updates (if subscribed) - read from cache instead of hitting DB
-            _ = alerts_interval.tick(), if alerts_subscribed => {
-                if let Some(cached_anomalies) = state.cache.get("anomalies") {
+            _ = alerts_interval.tick(), if alerts_subscribed && has_db => {
+                if let Some(cached_anomalies) = cache.as_ref().unwrap().get("anomalies") {
                     // Only send if there are new alerts and they differ from last sent
                     if *cached_anomalies != last_alerts {
                         let alerts_array = cached_anomalies.get("alerts").cloned().unwrap_or(serde_json::json!([]));
@@ -2178,3 +2191,44 @@ async fn websocket_connection(mut socket: WebSocket, state: ApiState) {
         events_received
     );
 }
+
+// ---------------------------------------------------------------------------
+// Minimal API for --no-database mode (WebSocket + health only, no DB routes)
+// ---------------------------------------------------------------------------
+
+/// Lightweight state for --no-database mode. Only carries the components needed
+/// for WebSocket event streaming and health checks — no DB store or cache.
+#[derive(Clone)]
+pub struct MinimalApiState {
+    pub telemetry_server: Arc<TelemetryServer>,
+    pub broadcaster: Arc<EventBroadcaster>,
+}
+
+/// Create a minimal router for --no-database mode.
+/// Only registers WebSocket and health endpoints — no DB-backed routes.
+pub fn create_minimal_router(state: MinimalApiState) -> Router {
+    Router::new()
+        .route("/api/health", get(health_check))
+        .route("/api/ws", get(minimal_websocket_handler))
+        .layer(TimeoutLayer::new(std::time::Duration::from_secs(30)))
+        .layer(CorsLayer::permissive())
+        .with_state(state)
+}
+
+async fn minimal_websocket_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<MinimalApiState>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let current = ACTIVE_WS_CONNECTIONS.load(std::sync::atomic::Ordering::Relaxed);
+    if current >= MAX_WS_CONNECTIONS {
+        warn!(
+            "WebSocket connection limit reached ({})",
+            MAX_WS_CONNECTIONS
+        );
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    Ok(ws.on_upgrade(move |socket| {
+        websocket_connection(socket, state.broadcaster, state.telemetry_server, None, None)
+    }))
+}
+

--- a/src/api.rs
+++ b/src/api.rs
@@ -1820,6 +1820,11 @@ async fn websocket_handler(
 /// Send timeout for WebSocket messages - prevents slow clients from blocking
 const WS_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Max events per WS message. Opportunistic batching: after receiving one event,
+/// drain up to this many more via try_recv() (non-blocking). At batch=10,
+/// ws-synth measured 1.2M events/s vs 158K unbatched.
+const WS_BATCH_SIZE: usize = 10;
+
 async fn websocket_connection(
     mut socket: WebSocket,
     broadcaster: Arc<EventBroadcaster>,
@@ -1883,16 +1888,28 @@ async fn websocket_connection(
     let mut events_received = 0u64;
     let mut last_event_time = chrono::Utc::now();
 
+    // Debug: track WS loop health
+    let mut debug_events_since_log = 0u64;
+    let mut debug_last_log = tokio::time::Instant::now();
+    let mut debug_send_time_us = 0u64;
+    let mut debug_sends_since_log = 0u64;
+    let mut debug_lagged_total = 0u64;
+    let mut debug_loop_iterations = 0u64;
+
     loop {
+        debug_loop_iterations += 1;
         tokio::select! {
             // Real-time event streaming from broadcaster
-            Ok(event) = event_receiver.recv() => {
-                events_received += 1;
+            result = event_receiver.recv() => {
+            match result {
+            Ok(event) => {
+                // Opportunistic batching: collect first event, then drain more via try_recv()
+                let mut batch: Vec<std::sync::Arc<str>> = Vec::with_capacity(WS_BATCH_SIZE);
 
-                // Use pre-serialized JSON if available (avoids re-serializing per subscriber)
-                let msg = if let Some(ref json) = event.serialized_json {
-                    json.to_string()
+                if let Some(ref json) = event.serialized_json {
+                    batch.push(std::sync::Arc::clone(json));
                 } else {
+                    // Fallback: serialize on the fly
                     let response = WebSocketResponse {
                         r#type: "event".to_string(),
                         data: serde_json::json!({
@@ -1903,23 +1920,97 @@ async fn websocket_connection(
                         }),
                         timestamp: chrono::Utc::now(),
                     };
-                    match serialize_ws_message(&response) {
-                        Some(m) => m,
-                        None => break,
-                    }
-                };
-
-                // Send with timeout to prevent slow clients from blocking
-                match tokio::time::timeout(WS_SEND_TIMEOUT, socket.send(Message::Text(msg))).await {
-                    Ok(Ok(_)) => {}
-                    Ok(Err(_)) => break, // Send error
-                    Err(_) => {
-                        warn!("WebSocket send timeout, closing slow client");
-                        break; // Timeout
+                    if let Some(m) = serialize_ws_message(&response) {
+                        batch.push(std::sync::Arc::from(m));
                     }
                 }
 
+                // Drain more events without blocking
+                while batch.len() < WS_BATCH_SIZE {
+                    match event_receiver.try_recv() {
+                        Ok(ev) => {
+                            if let Some(ref json) = ev.serialized_json {
+                                batch.push(std::sync::Arc::clone(json));
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::TryRecvError::Lagged(n)) => {
+                            debug_lagged_total += n;
+                        }
+                        Err(tokio::sync::broadcast::error::TryRecvError::Empty
+                            | tokio::sync::broadcast::error::TryRecvError::Closed) => break,
+                    }
+                }
+
+                if batch.is_empty() {
+                    continue;
+                }
+
+                let batch_len = batch.len() as u64;
+                events_received += batch_len;
+                debug_events_since_log += batch_len;
+
+                // Build message: single event as-is, multiple events in batch envelope
+                let msg = if batch.len() == 1 {
+                    batch[0].to_string()
+                } else {
+                    let total_len: usize = batch.iter().map(|s| s.len()).sum::<usize>() + batch.len() + 80;
+                    let mut buf = String::with_capacity(total_len);
+                    buf.push_str(r#"{"type":"batch","data":["#);
+                    for (i, json) in batch.iter().enumerate() {
+                        if i > 0 { buf.push(','); }
+                        buf.push_str(json);
+                    }
+                    buf.push_str(r#"],"timestamp":""#);
+                    buf.push_str(&chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true));
+                    buf.push_str(r#""}"#);
+                    buf
+                };
+
+                // Send with timeout to prevent slow clients from blocking
+                let send_start = tokio::time::Instant::now();
+                match tokio::time::timeout(WS_SEND_TIMEOUT, socket.send(Message::Text(msg))).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => {
+                        warn!("WebSocket send error after {} events: {}", events_received, e);
+                        break;
+                    }
+                    Err(_) => {
+                        warn!("WebSocket send timeout after {} events", events_received);
+                        break;
+                    }
+                }
+                debug_send_time_us += send_start.elapsed().as_micros() as u64;
+                debug_sends_since_log += 1;
+
+                // Periodic debug log every 2 seconds
+                if debug_last_log.elapsed() >= std::time::Duration::from_secs(2) {
+                    let elapsed = debug_last_log.elapsed().as_secs_f64();
+                    let avg_send_us = if debug_sends_since_log > 0 { debug_send_time_us / debug_sends_since_log } else { 0 };
+                    warn!(
+                        "WS debug: {:.0} events/s, avg_send={}us, lagged_total={}, loops={}, broadcast_lag={}",
+                        debug_events_since_log as f64 / elapsed,
+                        avg_send_us,
+                        debug_lagged_total,
+                        debug_loop_iterations,
+                        event_receiver.len(),
+                    );
+                    debug_events_since_log = 0;
+                    debug_send_time_us = 0;
+                    debug_sends_since_log = 0;
+                    debug_loop_iterations = 0;
+                    debug_last_log = tokio::time::Instant::now();
+                }
+
                 last_event_time = chrono::Utc::now();
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                debug_lagged_total += n;
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                warn!("Broadcast channel closed, ending WS connection");
+                break;
+            }
+            } // match result
             }
 
             // Handle client messages

--- a/src/batch_writer.rs
+++ b/src/batch_writer.rs
@@ -75,7 +75,10 @@ impl BatchWriter {
     /// Each worker locks the mutex briefly to drain events, then releases it and
     /// performs the slow DB write without holding the lock. This provides natural
     /// work-stealing: idle workers pick up events while busy workers are blocked on I/O.
-    pub fn new(store: Arc<EventStore>) -> Self {
+    ///
+    /// When `store` is `None` (--no-database mode), workers still drain the channel
+    /// to prevent backpressure/OOM but skip all DB writes.
+    pub fn new(store: Option<Arc<EventStore>>) -> Self {
         let (sender, receiver) = mpsc::channel(CHANNEL_SIZE);
         let shared_rx = Arc::new(Mutex::new(receiver));
         let shared_node_counts: Arc<Mutex<HashMap<NodeId, u64>>> =
@@ -83,7 +86,7 @@ impl BatchWriter {
 
         // Single dedicated task for flushing node stats to DB.
         // Aggregates counts from all writers, preventing deadlocks from concurrent UPDATEs.
-        {
+        if let Some(ref store) = store {
             let counts = shared_node_counts.clone();
             let store = store.clone();
             tokio::spawn(async move {
@@ -247,7 +250,7 @@ impl BatchWriter {
 async fn writer_worker(
     id: usize,
     receiver: Arc<Mutex<Receiver<WriterCommand>>>,
-    store: Arc<EventStore>,
+    store: Option<Arc<EventStore>>,
     shared_node_counts: Arc<Mutex<HashMap<NodeId, u64>>>,
 ) -> Result<()> {
     let mut event_batch: Vec<EventRecord> = Vec::with_capacity(MAX_BATCH_SIZE);
@@ -273,26 +276,36 @@ async fn writer_worker(
         .await;
 
         // Phase 2: Flush EVENT batch to DB (slow, milliseconds — NO lock held)
+        // In no-database mode, just discard the events (channel was drained to prevent OOM)
         if !event_batch.is_empty() {
-            let result = flush_events(&store, &mut event_batch).await;
-            if let Err(e) = result {
-                error!("Writer {} event flush error: {}", id, e);
+            if let Some(ref store) = store {
+                let result = flush_events(store, &mut event_batch).await;
+                if let Err(e) = result {
+                    error!("Writer {} event flush error: {}", id, e);
+                }
+            } else {
+                event_batch.clear();
             }
         }
 
         // Phase 3: Flush node connect/disconnect immediately
         // These are rare events (~1024 total) so no need to batch on a timer
-        if !node_connects.is_empty() {
-            let connects = std::mem::take(&mut node_connects);
-            if let Err(e) = store.store_nodes_connected_batch(&connects).await {
-                warn!("Writer {} failed to flush node connects: {}", id, e);
+        if let Some(ref store) = store {
+            if !node_connects.is_empty() {
+                let connects = std::mem::take(&mut node_connects);
+                if let Err(e) = store.store_nodes_connected_batch(&connects).await {
+                    warn!("Writer {} failed to flush node connects: {}", id, e);
+                }
             }
-        }
-        if !node_disconnects.is_empty() {
-            let disconnects = std::mem::take(&mut node_disconnects);
-            if let Err(e) = store.store_nodes_disconnected_batch(&disconnects).await {
-                warn!("Writer {} failed to flush node disconnects: {}", id, e);
+            if !node_disconnects.is_empty() {
+                let disconnects = std::mem::take(&mut node_disconnects);
+                if let Err(e) = store.store_nodes_disconnected_batch(&disconnects).await {
+                    warn!("Writer {} failed to flush node disconnects: {}", id, e);
+                }
             }
+        } else {
+            node_connects.clear();
+            node_disconnects.clear();
         }
 
         // Send flush response after everything is written
@@ -316,17 +329,19 @@ async fn writer_worker(
 
         if should_shutdown {
             // Final event flush
-            if let Err(e) = flush_events(&store, &mut event_batch).await {
-                error!("Writer {} shutdown event flush error: {}", id, e);
-            }
-            // Final node updates flush
-            if !node_connects.is_empty() {
-                let _ = store.store_nodes_connected_batch(&node_connects).await;
-            }
-            if !node_disconnects.is_empty() {
-                let _ = store
-                    .store_nodes_disconnected_batch(&node_disconnects)
-                    .await;
+            if let Some(ref store) = store {
+                if let Err(e) = flush_events(store, &mut event_batch).await {
+                    error!("Writer {} shutdown event flush error: {}", id, e);
+                }
+                // Final node updates flush
+                if !node_connects.is_empty() {
+                    let _ = store.store_nodes_connected_batch(&node_connects).await;
+                }
+                if !node_disconnects.is_empty() {
+                    let _ = store
+                        .store_nodes_disconnected_batch(&node_disconnects)
+                        .await;
+                }
             }
             // Merge remaining node counts into shared aggregator
             if !node_counts.is_empty() {

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -586,6 +586,11 @@ async fn run_websocket(ws_url: String, run_ends: Instant) -> WsMetrics {
                         if let Ok(val) = serde_json::from_str::<serde_json::Value>(&text) {
                             match val.get("type").and_then(|t| t.as_str()) {
                                 Some("event") => metrics.events_received += 1,
+                                Some("batch") => {
+                                    if let Some(data) = val.get("data").and_then(|d| d.as_array()) {
+                                        metrics.events_received += data.len() as u64;
+                                    }
+                                }
                                 Some("stats") => metrics.stats_received += 1,
                                 Some("metrics") => metrics.metrics_received += 1,
                                 _ => {}

--- a/src/event_broadcaster.rs
+++ b/src/event_broadcaster.rs
@@ -261,7 +261,8 @@ impl EventBroadcaster {
             let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
             let _ = tx.send(broadcast_event.clone());
             node_channels.insert(record.node_id.to_string(), tx);
-            self.node_channel_count.store(node_channels.len(), Ordering::Relaxed);
+            self.node_channel_count
+                .store(node_channels.len(), Ordering::Relaxed);
         }
 
         // Ring buffer for API recent events
@@ -441,39 +442,59 @@ impl EventBroadcaster {
 
     /// Subscribe to a specific node's channel via aggregator command.
     /// Returns None if node_id hasn't connected yet (no events received).
-    pub async fn subscribe_node(&self, node_id: &str) -> Option<broadcast::Receiver<Arc<BroadcastEvent>>> {
+    pub async fn subscribe_node(
+        &self,
+        node_id: &str,
+    ) -> Option<broadcast::Receiver<Arc<BroadcastEvent>>> {
         let (tx, rx) = oneshot::channel();
-        let _ = self.command_sender.send(AggregatorCommand::SubscribeNode {
-            node_id: node_id.to_string(),
-            reply: tx,
-        }).await;
+        let _ = self
+            .command_sender
+            .send(AggregatorCommand::SubscribeNode {
+                node_id: node_id.to_string(),
+                reply: tx,
+            })
+            .await;
         rx.await.ok().flatten()
     }
 
     /// Subscribe to multiple nodes via aggregator command.
     /// Node IDs that haven't connected yet are silently skipped.
-    pub async fn subscribe_nodes(&self, node_ids: &[String]) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
+    pub async fn subscribe_nodes(
+        &self,
+        node_ids: &[String],
+    ) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
         let (tx, rx) = oneshot::channel();
-        let _ = self.command_sender.send(AggregatorCommand::SubscribeNodes {
-            node_ids: node_ids.to_vec(),
-            reply: tx,
-        }).await;
+        let _ = self
+            .command_sender
+            .send(AggregatorCommand::SubscribeNodes {
+                node_ids: node_ids.to_vec(),
+                reply: tx,
+            })
+            .await;
         rx.await.unwrap_or_default()
     }
 
     /// Subscribe to all currently-known node channels via aggregator command.
-    pub async fn subscribe_all_nodes(&self) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
+    pub async fn subscribe_all_nodes(
+        &self,
+    ) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
         let (tx, rx) = oneshot::channel();
-        let _ = self.command_sender.send(AggregatorCommand::SubscribeAllNodes { reply: tx }).await;
+        let _ = self
+            .command_sender
+            .send(AggregatorCommand::SubscribeAllNodes { reply: tx })
+            .await;
         rx.await.unwrap_or_default()
     }
 
     /// Remove a node's broadcast channel if no WS clients are subscribed.
     /// Called when a node's TCP connection drops.
     pub async fn remove_node_channel(&self, node_id: &str) {
-        let _ = self.command_sender.send(AggregatorCommand::RemoveNodeChannel {
-            node_id: node_id.to_string(),
-        }).await;
+        let _ = self
+            .command_sender
+            .send(AggregatorCommand::RemoveNodeChannel {
+                node_id: node_id.to_string(),
+            })
+            .await;
     }
 
     /// Get recent events for catch-up on new connections
@@ -523,7 +544,6 @@ impl EventBroadcaster {
             undelivered_events: self.undelivered_events.load(Ordering::Relaxed),
         }
     }
-
 }
 
 #[cfg(test)]
@@ -638,7 +658,10 @@ mod tests {
         send_via_aggregator(&broadcaster, "node_1").await;
 
         // Subscribe to node_1 via command
-        let mut rx_node1 = broadcaster.subscribe_node("node_1").await.expect("channel should exist");
+        let mut rx_node1 = broadcaster
+            .subscribe_node("node_1")
+            .await
+            .expect("channel should exist");
 
         // Send more events
         send_via_aggregator(&broadcaster, "node_1").await;
@@ -664,11 +687,15 @@ mod tests {
         }
 
         // Subscribe to node_a and node_b
-        let subs = broadcaster.subscribe_nodes(&["node_a".to_string(), "node_b".to_string()]).await;
+        let subs = broadcaster
+            .subscribe_nodes(&["node_a".to_string(), "node_b".to_string()])
+            .await;
         assert_eq!(subs.len(), 2);
 
         // Subscribe to non-existent node — should be skipped
-        let subs2 = broadcaster.subscribe_nodes(&["node_a".to_string(), "nonexistent".to_string()]).await;
+        let subs2 = broadcaster
+            .subscribe_nodes(&["node_a".to_string(), "nonexistent".to_string()])
+            .await;
         assert_eq!(subs2.len(), 1);
 
         // subscribe_all_nodes should return all 3
@@ -807,7 +834,14 @@ mod tests {
         let id = broadcaster.next_event_id();
         let event_type = event.event_type() as u8;
         let timestamp = chrono::Utc::now();
-        let ws_json = build_ws_envelope(id, "node_1", event_type, &event_json, timestamp, &mut ws_buf);
+        let ws_json = build_ws_envelope(
+            id,
+            "node_1",
+            event_type,
+            &event_json,
+            timestamp,
+            &mut ws_buf,
+        );
 
         let record = BroadcastRecord {
             id,

--- a/src/event_broadcaster.rs
+++ b/src/event_broadcaster.rs
@@ -1,11 +1,11 @@
 use crate::events::Event;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc};
-use tracing::{debug, trace, warn};
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tracing::debug;
 
 /// Size of the main broadcast channel
 /// 500K provides ~5 seconds of buffer at peak throughput (100K events/sec)
@@ -25,6 +25,28 @@ const AGGREGATION_CHANNEL_SIZE: usize = 500_000;
 /// At 600K events/s this gives ~60 yields/s = yield every ~16ms,
 /// preventing WS loop starvation (observed 700ms stalls without this).
 const AGGREGATOR_DRAIN_LIMIT: usize = 10_000;
+
+/// Size of the command channel for WS subscribe/unsubscribe requests.
+const COMMAND_CHANNEL_SIZE: usize = 256;
+
+/// Commands sent from WS handlers to the aggregator task.
+/// The aggregator owns the node channels HashMap — all access goes through here.
+enum AggregatorCommand {
+    SubscribeNode {
+        node_id: String,
+        reply: oneshot::Sender<Option<broadcast::Receiver<Arc<BroadcastEvent>>>>,
+    },
+    SubscribeNodes {
+        node_ids: Vec<String>,
+        reply: oneshot::Sender<Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)>>,
+    },
+    SubscribeAllNodes {
+        reply: oneshot::Sender<Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)>>,
+    },
+    RemoveNodeChannel {
+        node_id: String,
+    },
+}
 
 /// Broadcast event tuple: (node_id, event, event_json).
 pub type BroadcastRecord = (Arc<str>, Arc<Event>, Arc<[u8]>);
@@ -101,9 +123,8 @@ pub struct BroadcasterStats {
 
 /// High-performance event broadcaster designed for 1024+ nodes.
 ///
-/// Uses `parking_lot::RwLock` instead of `tokio::sync::RwLock` for the recent_events
-/// ring buffer and node_channels map because the critical sections contain no await
-/// points. This avoids async lock overhead on the hottest path.
+/// Node channels are owned exclusively by the aggregator task (no shared lock).
+/// WS handlers communicate via a command channel (mpsc) with oneshot replies.
 pub struct EventBroadcaster {
     /// MPSC sender for connection handlers to submit event batches to the aggregator.
     /// `try_send()` is lock-free — no contention between 1023 connection tasks.
@@ -115,15 +136,21 @@ pub struct EventBroadcaster {
     /// Main broadcast channel for all events
     sender: broadcast::Sender<Arc<BroadcastEvent>>,
 
-    /// Per-node broadcast channels for filtered subscriptions
-    node_channels: Arc<RwLock<HashMap<String, broadcast::Sender<Arc<BroadcastEvent>>>>>,
+    /// Command channel for WS handlers to subscribe/unsubscribe from node channels.
+    command_sender: mpsc::Sender<AggregatorCommand>,
+
+    /// Command receiver, taken once by `start_aggregator()`.
+    command_receiver: Mutex<Option<mpsc::Receiver<AggregatorCommand>>>,
 
     /// Ring buffer of recent events for new connections
-    /// Uses parking_lot::RwLock for fast sync access (no await points in critical section)
-    recent_events: Arc<RwLock<VecDeque<Arc<BroadcastEvent>>>>,
+    /// Uses parking_lot::Mutex for fast sync access (no await points in critical section)
+    recent_events: Arc<Mutex<VecDeque<Arc<BroadcastEvent>>>>,
 
     /// Event counter for unique IDs
     event_counter: Arc<AtomicU64>,
+
+    /// Node channel count — updated by aggregator, read by get_stats()
+    node_channel_count: Arc<AtomicUsize>,
 
     /// Statistics
     total_broadcast: Arc<AtomicU64>,
@@ -141,50 +168,49 @@ impl EventBroadcaster {
     pub fn new() -> Self {
         let (sender, _) = broadcast::channel(BROADCAST_CHANNEL_SIZE);
         let (event_sender, event_receiver) = mpsc::channel(AGGREGATION_CHANNEL_SIZE);
+        let (command_sender, command_receiver) = mpsc::channel(COMMAND_CHANNEL_SIZE);
 
-        let broadcaster = Self {
+        Self {
             event_sender,
             event_receiver: Mutex::new(Some(event_receiver)),
             sender,
-            node_channels: Arc::new(RwLock::new(HashMap::with_capacity(1024))),
-            recent_events: Arc::new(RwLock::new(VecDeque::with_capacity(MAX_RETAINED_EVENTS))),
+            command_sender,
+            command_receiver: Mutex::new(Some(command_receiver)),
+            recent_events: Arc::new(Mutex::new(VecDeque::with_capacity(MAX_RETAINED_EVENTS))),
             event_counter: Arc::new(AtomicU64::new(0)),
+            node_channel_count: Arc::new(AtomicUsize::new(0)),
             total_broadcast: Arc::new(AtomicU64::new(0)),
-            dropped_events: Arc::new(AtomicU64::new(0)), // Note: Real drops happen inside receivers
+            dropped_events: Arc::new(AtomicU64::new(0)),
             undelivered_events: Arc::new(AtomicU64::new(0)),
-        };
-
-        broadcaster
+        }
     }
 
     /// Broadcast an event to all subscribers.
-    /// Optimized for high throughput with minimal latency.
-    /// `event_json` is the pre-serialized standalone Event JSON (serialized once in server.rs).
-    /// `ws_buf` is a reusable buffer for building the WS envelope JSON.
-    pub fn broadcast_event(
+    /// Called only from the aggregator task — `node_channels` is the aggregator's local HashMap.
+    /// No locks on the hot path (node_channels is plain HashMap, not behind RwLock).
+    fn broadcast_event(
         &self,
         node_id: Arc<str>,
         event: Arc<Event>,
         event_json: &[u8],
         ws_buf: &mut Vec<u8>,
-    ) -> Result<u64, broadcast::error::SendError<Arc<BroadcastEvent>>> {
-        // Generate unique event ID
+        node_channels: &mut HashMap<String, broadcast::Sender<Arc<BroadcastEvent>>>,
+    ) -> u64 {
         let id = self.event_counter.fetch_add(1, Ordering::Relaxed);
 
         let main_receivers = self.sender.receiver_count();
-
-        // Check if anyone is listening on this node's channel
-        let node_has_receivers = {
-            let nc = self.node_channels.read();
-            nc.get(&*node_id).map_or(false, |s| s.receiver_count() > 0)
-        };
+        let node_has_receivers = node_channels
+            .get(&*node_id)
+            .map_or(false, |s| s.receiver_count() > 0);
 
         // Fast path: no subscribers at all.
-        // Still update the ring buffer for API /events catch-up, but skip
-        // JSON serialization, broadcast channel send, and node-channel dispatch.
         if main_receivers == 0 && !node_has_receivers {
-            // Ensure node channel exists (no send needed — no receivers)
-            self.ensure_node_channel(&node_id);
+            // Ensure node channel exists for future subscribers
+            if !node_channels.contains_key(&*node_id) {
+                let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
+                node_channels.insert(node_id.to_string(), tx);
+                self.node_channel_count.store(node_channels.len(), Ordering::Relaxed);
+            }
 
             let broadcast_event = Arc::new(BroadcastEvent {
                 id,
@@ -198,16 +224,15 @@ impl EventBroadcaster {
             self.total_broadcast.fetch_add(1, Ordering::Relaxed);
             self.undelivered_events.fetch_add(1, Ordering::Relaxed);
 
-            // Ring buffer for API recent events
             {
-                let mut recent = self.recent_events.write();
+                let mut recent = self.recent_events.lock();
                 if recent.len() >= MAX_RETAINED_EVENTS {
                     recent.pop_front();
                 }
                 recent.push_back(broadcast_event);
             }
 
-            return Ok(id);
+            return id;
         }
 
         let event_type = event.event_type() as u8;
@@ -222,10 +247,7 @@ impl EventBroadcaster {
         };
 
         // Pre-serialize WS envelope using RawValue to avoid re-serializing the Event.
-        // The event_json bytes were produced by serde_json::to_vec, so they're valid JSON.
-        // Serialize when main channel or node channel has subscribers.
         if main_receivers > 0 || node_has_receivers {
-            // SAFETY: serde_json::to_vec always produces valid UTF-8
             if let Ok(raw_str) = std::str::from_utf8(event_json) {
                 if let Ok(raw_value) = serde_json::value::RawValue::from_string(raw_str.to_string())
                 {
@@ -241,7 +263,6 @@ impl EventBroadcaster {
                     };
                     ws_buf.clear();
                     if serde_json::to_writer(&mut *ws_buf, &ws_response).is_ok() {
-                        // SAFETY: serde_json always produces valid UTF-8
                         let json_str = unsafe { std::str::from_utf8_unchecked(ws_buf) };
                         broadcast_event.serialized_json = Some(Arc::from(json_str));
                     }
@@ -252,35 +273,31 @@ impl EventBroadcaster {
         let broadcast_event = Arc::new(broadcast_event);
 
         // Broadcast to main channel
-        match self.sender.send(broadcast_event.clone()) {
-            Ok(_) => {
-                debug!("Broadcast event {} to {} receivers", id, main_receivers);
-                self.total_broadcast.fetch_add(1, Ordering::Relaxed);
-            }
-            Err(_) => {
-                self.total_broadcast.fetch_add(1, Ordering::Relaxed);
-                if main_receivers > 0 {
-                    warn!(
-                        "Unexpected broadcast error with {} active receivers",
-                        main_receivers
-                    );
-                }
-            }
+        if main_receivers > 0 {
+            let _ = self.sender.send(broadcast_event.clone());
+        }
+        self.total_broadcast.fetch_add(1, Ordering::Relaxed);
+
+        // Dispatch to per-node channel (create on first event for this node)
+        if let Some(sender) = node_channels.get(&*node_id) {
+            let _ = sender.send(broadcast_event.clone());
+        } else {
+            let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
+            let _ = tx.send(broadcast_event.clone());
+            node_channels.insert(node_id.to_string(), tx);
+            self.node_channel_count.store(node_channels.len(), Ordering::Relaxed);
         }
 
-        // Dispatch to per-node channel (create on first event for this node).
-        self.dispatch_to_node_channel(&node_id, &broadcast_event);
-
-        // Add to recent events ring buffer (O(1) operations with VecDeque)
+        // Ring buffer for API recent events
         {
-            let mut recent = self.recent_events.write();
+            let mut recent = self.recent_events.lock();
             if recent.len() >= MAX_RETAINED_EVENTS {
                 recent.pop_front();
             }
             recent.push_back(broadcast_event);
         }
 
-        Ok(id)
+        id
     }
 
     /// Submit an event to the aggregation channel for processing.
@@ -322,11 +339,21 @@ impl EventBroadcaster {
             .take()
             .expect("start_aggregator() must be called exactly once");
 
+        let mut cmd_receiver = self
+            .command_receiver
+            .lock()
+            .take()
+            .expect("start_aggregator() must be called exactly once");
+
         let this = Arc::clone(self);
 
         tokio::spawn(async move {
             // Reusable buffer for building WS envelope JSON (avoids per-event allocation)
             let mut ws_buf: Vec<u8> = Vec::with_capacity(4096);
+
+            // Node channels owned exclusively by this task — no lock needed
+            let mut node_channels: HashMap<String, broadcast::Sender<Arc<BroadcastEvent>>> =
+                HashMap::with_capacity(1024);
 
             // Debug stats
             let mut debug_last_log = tokio::time::Instant::now();
@@ -335,59 +362,88 @@ impl EventBroadcaster {
             let mut debug_drain_max_us = 0u64;
             let mut debug_drain_count = 0u64;
 
-            // Drain all available batches per wakeup for throughput
-            while let Some(batch) = receiver.recv().await {
-                let drain_start = tokio::time::Instant::now();
-                let mut drain_events = 0u64;
+            loop {
+                tokio::select! {
+                    Some(batch) = receiver.recv() => {
+                        let drain_start = tokio::time::Instant::now();
+                        let mut drain_events = 0u64;
 
-                for (node_id, event, event_json) in batch.events {
-                    let _ = this.broadcast_event(node_id, event, &event_json, &mut ws_buf);
-                    drain_events += 1;
-                }
+                        for (node_id, event, event_json) in batch.events {
+                            this.broadcast_event(node_id, event, &event_json, &mut ws_buf, &mut node_channels);
+                            drain_events += 1;
+                        }
 
-                // Drain additional buffered batches, but yield after AGGREGATOR_DRAIN_LIMIT
-                // to prevent starving the WS send loop on the same tokio runtime.
-                while (drain_events as usize) < AGGREGATOR_DRAIN_LIMIT {
-                    match receiver.try_recv() {
-                        Ok(batch) => {
-                            for (node_id, event, event_json) in batch.events {
-                                let _ = this.broadcast_event(node_id, event, &event_json, &mut ws_buf);
-                                drain_events += 1;
+                        // Drain additional buffered batches, but yield after AGGREGATOR_DRAIN_LIMIT
+                        while (drain_events as usize) < AGGREGATOR_DRAIN_LIMIT {
+                            match receiver.try_recv() {
+                                Ok(batch) => {
+                                    for (node_id, event, event_json) in batch.events {
+                                        this.broadcast_event(node_id, event, &event_json, &mut ws_buf, &mut node_channels);
+                                        drain_events += 1;
+                                    }
+                                }
+                                Err(_) => break,
                             }
                         }
-                        Err(_) => break,
+
+                        let drain_us = drain_start.elapsed().as_micros() as u64;
+                        debug_events_total += drain_events;
+                        debug_drain_count += 1;
+                        if drain_events > debug_drain_max_events {
+                            debug_drain_max_events = drain_events;
+                        }
+                        if drain_us > debug_drain_max_us {
+                            debug_drain_max_us = drain_us;
+                        }
+
+                        if debug_last_log.elapsed() >= std::time::Duration::from_secs(2) {
+                            let elapsed = debug_last_log.elapsed().as_secs_f64();
+                            debug!(
+                                "Aggregator stats: {:.0} events/s, drains={}, max_drain_events={}, max_drain_us={}, mpsc_lag={}",
+                                debug_events_total as f64 / elapsed,
+                                debug_drain_count,
+                                debug_drain_max_events,
+                                debug_drain_max_us,
+                                receiver.len(),
+                            );
+                            debug_events_total = 0;
+                            debug_drain_max_events = 0;
+                            debug_drain_max_us = 0;
+                            debug_drain_count = 0;
+                            debug_last_log = tokio::time::Instant::now();
+                        }
+                    }
+
+                    Some(cmd) = cmd_receiver.recv() => {
+                        match cmd {
+                            AggregatorCommand::SubscribeNode { node_id, reply } => {
+                                let rx = node_channels.get(&node_id).map(|s| s.subscribe());
+                                let _ = reply.send(rx);
+                            }
+                            AggregatorCommand::SubscribeNodes { node_ids, reply } => {
+                                let subs = node_ids.iter()
+                                    .filter_map(|id| node_channels.get(id).map(|s| (id.clone(), s.subscribe())))
+                                    .collect();
+                                let _ = reply.send(subs);
+                            }
+                            AggregatorCommand::SubscribeAllNodes { reply } => {
+                                let subs = node_channels.iter()
+                                    .map(|(id, s)| (id.clone(), s.subscribe()))
+                                    .collect();
+                                let _ = reply.send(subs);
+                            }
+                            AggregatorCommand::RemoveNodeChannel { node_id } => {
+                                if let Some(sender) = node_channels.get(&node_id) {
+                                    if sender.receiver_count() == 0 {
+                                        node_channels.remove(&node_id);
+                                        this.node_channel_count.store(node_channels.len(), Ordering::Relaxed);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-
-                let drain_us = drain_start.elapsed().as_micros() as u64;
-                debug_events_total += drain_events;
-                debug_drain_count += 1;
-                if drain_events > debug_drain_max_events {
-                    debug_drain_max_events = drain_events;
-                }
-                if drain_us > debug_drain_max_us {
-                    debug_drain_max_us = drain_us;
-                }
-
-                // Log every 2 seconds
-                if debug_last_log.elapsed() >= std::time::Duration::from_secs(2) {
-                    let elapsed = debug_last_log.elapsed().as_secs_f64();
-                    debug!(
-                        "Aggregator stats: {:.0} events/s, drains={}, max_drain_events={}, max_drain_us={}, mpsc_lag={}",
-                        debug_events_total as f64 / elapsed,
-                        debug_drain_count,
-                        debug_drain_max_events,
-                        debug_drain_max_us,
-                        receiver.len(),
-                    );
-                    debug_events_total = 0;
-                    debug_drain_max_events = 0;
-                    debug_drain_max_us = 0;
-                    debug_drain_count = 0;
-                    debug_last_log = tokio::time::Instant::now();
-                }
             }
-            trace!("Aggregator task exiting — all senders dropped");
         });
     }
 
@@ -396,46 +452,47 @@ impl EventBroadcaster {
         self.sender.subscribe()
     }
 
-    /// Subscribe to a specific node's channel.
+    /// Subscribe to a specific node's channel via aggregator command.
     /// Returns None if node_id hasn't connected yet (no events received).
-    pub fn subscribe_node(&self, node_id: &str) -> Option<broadcast::Receiver<Arc<BroadcastEvent>>> {
-        let channels = self.node_channels.read();
-        channels.get(node_id).map(|sender| sender.subscribe())
+    pub async fn subscribe_node(&self, node_id: &str) -> Option<broadcast::Receiver<Arc<BroadcastEvent>>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.command_sender.send(AggregatorCommand::SubscribeNode {
+            node_id: node_id.to_string(),
+            reply: tx,
+        }).await;
+        rx.await.ok().flatten()
     }
 
-    /// Subscribe to multiple nodes. Returns receivers keyed by node_id.
+    /// Subscribe to multiple nodes via aggregator command.
     /// Node IDs that haven't connected yet are silently skipped.
-    pub fn subscribe_nodes(&self, node_ids: &[String]) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
-        let channels = self.node_channels.read();
-        node_ids.iter()
-            .filter_map(|id| channels.get(id).map(|s| (id.clone(), s.subscribe())))
-            .collect()
+    pub async fn subscribe_nodes(&self, node_ids: &[String]) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.command_sender.send(AggregatorCommand::SubscribeNodes {
+            node_ids: node_ids.to_vec(),
+            reply: tx,
+        }).await;
+        rx.await.unwrap_or_default()
     }
 
-    /// Subscribe to all currently-known node channels.
-    /// Returns receivers for every node that has connected.
-    pub fn subscribe_all_nodes(&self) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
-        let channels = self.node_channels.read();
-        channels.iter()
-            .map(|(id, sender)| (id.clone(), sender.subscribe()))
-            .collect()
+    /// Subscribe to all currently-known node channels via aggregator command.
+    pub async fn subscribe_all_nodes(&self) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.command_sender.send(AggregatorCommand::SubscribeAllNodes { reply: tx }).await;
+        rx.await.unwrap_or_default()
     }
 
     /// Remove a node's broadcast channel if no WS clients are subscribed.
     /// Called when a node's TCP connection drops.
-    pub fn remove_node_channel(&self, node_id: &str) {
-        let mut channels = self.node_channels.write();
-        if let Some(sender) = channels.get(node_id) {
-            if sender.receiver_count() == 0 {
-                channels.remove(node_id);
-            }
-        }
+    pub async fn remove_node_channel(&self, node_id: &str) {
+        let _ = self.command_sender.send(AggregatorCommand::RemoveNodeChannel {
+            node_id: node_id.to_string(),
+        }).await;
     }
 
     /// Get recent events for catch-up on new connections
     /// Returns up to `limit` most recent events
     pub fn get_recent_events(&self, limit: Option<usize>) -> Vec<Arc<BroadcastEvent>> {
-        let recent = self.recent_events.read();
+        let recent = self.recent_events.lock();
         let limit = limit.unwrap_or(recent.len()).min(recent.len());
 
         if limit == 0 {
@@ -453,7 +510,7 @@ impl EventBroadcaster {
         node_id: &str,
         limit: usize,
     ) -> Vec<Arc<BroadcastEvent>> {
-        let recent = self.recent_events.read();
+        let recent = self.recent_events.lock();
         // Single pass: collect from reverse iterator, then reverse the result
         let mut result = Vec::with_capacity(limit.min(recent.len()));
         for event in recent.iter().rev() {
@@ -473,47 +530,13 @@ impl EventBroadcaster {
         BroadcasterStats {
             total_events_broadcast: self.total_broadcast.load(Ordering::Relaxed),
             active_subscribers: self.sender.receiver_count(),
-            node_channels: self.node_channels.read().len(),
-            events_in_buffer: self.recent_events.read().len(),
+            node_channels: self.node_channel_count.load(Ordering::Relaxed),
+            events_in_buffer: self.recent_events.lock().len(),
             dropped_events: self.dropped_events.load(Ordering::Relaxed),
             undelivered_events: self.undelivered_events.load(Ordering::Relaxed),
         }
     }
 
-    /// Dispatch an event to the per-node broadcast channel, creating it on first use.
-    /// The write-lock path triggers at most once per node (1024 times total over
-    /// the server's lifetime). After that, only the read-lock fast path is taken.
-    fn dispatch_to_node_channel(&self, node_id: &Arc<str>, broadcast_event: &Arc<BroadcastEvent>) {
-        let node_channels = self.node_channels.read();
-        if let Some(sender) = node_channels.get(&**node_id) {
-            let _ = sender.send(broadcast_event.clone());
-        } else {
-            drop(node_channels);
-            let mut nc = self.node_channels.write();
-            // Double-check after acquiring write lock
-            if let Some(sender) = nc.get(&**node_id) {
-                let _ = sender.send(broadcast_event.clone());
-            } else {
-                let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
-                let _ = tx.send(broadcast_event.clone());
-                nc.insert(node_id.to_string(), tx);
-            }
-        }
-    }
-
-    /// Ensure a per-node broadcast channel exists, creating it on first use.
-    fn ensure_node_channel(&self, node_id: &Arc<str>) {
-        let node_channels = self.node_channels.read();
-        if node_channels.contains_key(&**node_id) {
-            return;
-        }
-        drop(node_channels);
-        let mut nc = self.node_channels.write();
-        if !nc.contains_key(&**node_id) {
-            let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
-            nc.insert(node_id.to_string(), tx);
-        }
-    }
 }
 
 #[cfg(test)]
@@ -536,27 +559,45 @@ mod tests {
         Arc::from(s)
     }
 
+    /// Helper: call broadcast_event with a local node_channels HashMap (no aggregator needed).
+    fn broadcast_direct(
+        broadcaster: &EventBroadcaster,
+        nid: &str,
+        event: Arc<Event>,
+        json: &[u8],
+        ws_buf: &mut Vec<u8>,
+        node_channels: &mut HashMap<String, broadcast::Sender<Arc<BroadcastEvent>>>,
+    ) -> u64 {
+        broadcaster.broadcast_event(node_id(nid), event, json, ws_buf, node_channels)
+    }
+
+    /// Helper: start aggregator and send events via MPSC (for subscribe tests).
+    async fn send_via_aggregator(broadcaster: &Arc<EventBroadcaster>, nid: &str) {
+        let event = make_test_event(nid);
+        let json: Arc<[u8]> = Arc::from(serde_json::to_vec(&*event).unwrap());
+        broadcaster.send_event(Arc::from(nid), event, json);
+        // Give aggregator time to process
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
     #[tokio::test]
     async fn test_broadcaster_scale() {
-        let broadcaster = EventBroadcaster::new();
-        let mut ws_buf = Vec::new();
+        let broadcaster = Arc::new(EventBroadcaster::new());
+        broadcaster.start_aggregator();
 
-        // Create channels by broadcasting events for 1024 nodes
+        // Create channels by sending events for 1024 nodes via aggregator
         for i in 0..1024 {
             let nid = format!("node_{}", i);
             let event = make_test_event(&nid);
-            let json = make_test_json(&event);
-            broadcaster
-                .broadcast_event(node_id(&nid), event, &json, &mut ws_buf)
-                .unwrap();
+            let json: Arc<[u8]> = Arc::from(serde_json::to_vec(&*event).unwrap());
+            broadcaster.send_event(Arc::from(nid.as_str()), event, json);
         }
+        // Give aggregator time to process all events
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Now subscribe to all — channels were created by broadcast_event
-        let receivers: Vec<_> = (0..1024)
-            .filter_map(|i| broadcaster.subscribe_node(&format!("node_{}", i)))
-            .collect();
-
-        assert_eq!(receivers.len(), 1024);
+        // Subscribe to all nodes via command
+        let subs = broadcaster.subscribe_all_nodes().await;
+        assert_eq!(subs.len(), 1024);
 
         let stats = broadcaster.get_stats();
         assert_eq!(stats.node_channels, 1024);
@@ -567,12 +608,11 @@ mod tests {
         let broadcaster = EventBroadcaster::new();
         let mut rx = broadcaster.subscribe_all();
         let mut ws_buf = Vec::new();
+        let mut nc = HashMap::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        let id = broadcaster
-            .broadcast_event(node_id("node_1"), event, &event_json, &mut ws_buf)
-            .unwrap();
+        let id = broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
         assert_eq!(id, 0);
 
         let received = rx.recv().await.unwrap();
@@ -586,12 +626,11 @@ mod tests {
         let mut rx1 = broadcaster.subscribe_all();
         let mut rx2 = broadcaster.subscribe_all();
         let mut ws_buf = Vec::new();
+        let mut nc = HashMap::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        broadcaster
-            .broadcast_event(node_id("node_1"), event, &event_json, &mut ws_buf)
-            .unwrap();
+        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
 
         let e1 = rx1.recv().await.unwrap();
         let e2 = rx2.recv().await.unwrap();
@@ -600,32 +639,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_subscribe_node_filters() {
-        let broadcaster = EventBroadcaster::new();
-        let mut ws_buf = Vec::new();
+        let broadcaster = Arc::new(EventBroadcaster::new());
+        broadcaster.start_aggregator();
 
-        // Broadcast first to create node_1 channel
-        let setup_event = make_test_event("node_1");
-        let setup_json = make_test_json(&setup_event);
-        broadcaster
-            .broadcast_event(node_id("node_1"), setup_event, &setup_json, &mut ws_buf)
-            .unwrap();
+        // Send event to create node_1 channel
+        send_via_aggregator(&broadcaster, "node_1").await;
 
-        // Now subscribe to node_1
-        let mut rx_node1 = broadcaster.subscribe_node("node_1").expect("channel should exist");
+        // Subscribe to node_1 via command
+        let mut rx_node1 = broadcaster.subscribe_node("node_1").await.expect("channel should exist");
 
-        // Broadcast to node_1 — should be received
-        let event1 = make_test_event("node_1");
-        let json1 = make_test_json(&event1);
-        broadcaster
-            .broadcast_event(node_id("node_1"), event1, &json1, &mut ws_buf)
-            .unwrap();
-
-        // Broadcast to node_2 — should NOT be received on node_1 channel
-        let event2 = make_test_event("node_2");
-        let json2 = make_test_json(&event2);
-        broadcaster
-            .broadcast_event(node_id("node_2"), event2, &json2, &mut ws_buf)
-            .unwrap();
+        // Send more events
+        send_via_aggregator(&broadcaster, "node_1").await;
+        send_via_aggregator(&broadcaster, "node_2").await;
 
         let received = rx_node1.recv().await.unwrap();
         assert_eq!(&*received.node_id, "node_1");
@@ -638,28 +663,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_subscribe_nodes_multi() {
-        let broadcaster = EventBroadcaster::new();
-        let mut ws_buf = Vec::new();
+        let broadcaster = Arc::new(EventBroadcaster::new());
+        broadcaster.start_aggregator();
 
-        // Create channels by broadcasting
+        // Create channels via aggregator
         for nid in &["node_a", "node_b", "node_c"] {
-            let event = make_test_event(nid);
-            let json = make_test_json(&event);
-            broadcaster
-                .broadcast_event(node_id(nid), event, &json, &mut ws_buf)
-                .unwrap();
+            send_via_aggregator(&broadcaster, nid).await;
         }
 
         // Subscribe to node_a and node_b
-        let subs = broadcaster.subscribe_nodes(&["node_a".to_string(), "node_b".to_string()]);
+        let subs = broadcaster.subscribe_nodes(&["node_a".to_string(), "node_b".to_string()]).await;
         assert_eq!(subs.len(), 2);
 
         // Subscribe to non-existent node — should be skipped
-        let subs2 = broadcaster.subscribe_nodes(&["node_a".to_string(), "nonexistent".to_string()]);
+        let subs2 = broadcaster.subscribe_nodes(&["node_a".to_string(), "nonexistent".to_string()]).await;
         assert_eq!(subs2.len(), 1);
 
         // subscribe_all_nodes should return all 3
-        let all = broadcaster.subscribe_all_nodes();
+        let all = broadcaster.subscribe_all_nodes().await;
         assert_eq!(all.len(), 3);
     }
 
@@ -667,25 +688,19 @@ mod tests {
     async fn test_recent_events() {
         let broadcaster = EventBroadcaster::new();
         let mut ws_buf = Vec::new();
+        let mut nc = HashMap::new();
 
         // Broadcast 5 events
         for i in 0..5 {
-            let event = make_test_event(&format!("node_{}", i));
+            let nid = format!("node_{}", i);
+            let event = make_test_event(&nid);
             let event_json = make_test_json(&event);
-            broadcaster
-                .broadcast_event(
-                    node_id(&format!("node_{}", i)),
-                    event,
-                    &event_json,
-                    &mut ws_buf,
-                )
-                .unwrap();
+            broadcast_direct(&broadcaster, &nid, event, &event_json, &mut ws_buf, &mut nc);
         }
 
         // Get last 3
         let recent = broadcaster.get_recent_events(Some(3));
         assert_eq!(recent.len(), 3);
-        // Should be the last 3 (ids 2, 3, 4)
         assert_eq!(recent[0].id, 2);
         assert_eq!(recent[2].id, 4);
 
@@ -698,21 +713,17 @@ mod tests {
     async fn test_recent_events_by_node() {
         let broadcaster = EventBroadcaster::new();
         let mut ws_buf = Vec::new();
+        let mut nc = HashMap::new();
 
-        // Broadcast from multiple nodes
         for _ in 0..3 {
             let event = make_test_event("node_a");
             let event_json = make_test_json(&event);
-            broadcaster
-                .broadcast_event(node_id("node_a"), event, &event_json, &mut ws_buf)
-                .unwrap();
+            broadcast_direct(&broadcaster, "node_a", event, &event_json, &mut ws_buf, &mut nc);
         }
         for _ in 0..2 {
             let event = make_test_event("node_b");
             let event_json = make_test_json(&event);
-            broadcaster
-                .broadcast_event(node_id("node_b"), event, &event_json, &mut ws_buf)
-                .unwrap();
+            broadcast_direct(&broadcaster, "node_b", event, &event_json, &mut ws_buf, &mut nc);
         }
 
         let node_a_events = broadcaster.get_recent_events_by_node("node_a", 10);
@@ -727,19 +738,16 @@ mod tests {
     async fn test_recent_events_ring_buffer() {
         let broadcaster = EventBroadcaster::new();
         let mut ws_buf = Vec::new();
+        let mut nc = HashMap::new();
 
-        // Broadcast more than MAX_RETAINED_EVENTS
         for _ in 0..(MAX_RETAINED_EVENTS + 100) {
             let event = make_test_event("node_1");
             let event_json = make_test_json(&event);
-            broadcaster
-                .broadcast_event(node_id("node_1"), event, &event_json, &mut ws_buf)
-                .unwrap();
+            broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
         }
 
         let recent = broadcaster.get_recent_events(None);
         assert_eq!(recent.len(), MAX_RETAINED_EVENTS);
-        // First event in buffer should be #100 (oldest were evicted)
         assert_eq!(recent[0].id, 100);
     }
 
@@ -748,12 +756,11 @@ mod tests {
         let broadcaster = EventBroadcaster::new();
         let _rx = broadcaster.subscribe_all();
         let mut ws_buf = Vec::new();
+        let mut nc = HashMap::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        broadcaster
-            .broadcast_event(node_id("node_1"), event, &event_json, &mut ws_buf)
-            .unwrap();
+        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
 
         let stats = broadcaster.get_stats();
         assert_eq!(stats.total_events_broadcast, 1);
@@ -763,7 +770,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_raw_value_ws_broadcast_matches_original() {
-        // Verify WsBroadcastRaw with RawValue produces identical JSON as WsBroadcast with &Event
         let event = Event::BestBlockChanged {
             timestamp: 1_000_000,
             slot: 42,
@@ -772,7 +778,6 @@ mod tests {
         let event_json = serde_json::to_vec(&event).unwrap();
         let now = chrono::Utc::now();
 
-        // Original: serialize with &Event
         let original = WsBroadcast {
             r#type: "event",
             data: WsBroadcastData {
@@ -785,7 +790,6 @@ mod tests {
         };
         let original_json = serde_json::to_string(&original).unwrap();
 
-        // New: serialize with RawValue
         let raw_str = std::str::from_utf8(&event_json).unwrap();
         let raw_value = serde_json::value::RawValue::from_string(raw_str.to_string()).unwrap();
         let raw = WsBroadcastRaw {
@@ -805,29 +809,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_broadcast_with_preserialized_json() {
-        // Verify broadcast_event with pre-serialized bytes stores correct serialized_json
         let broadcaster = EventBroadcaster::new();
         let _rx = broadcaster.subscribe_all(); // need a subscriber so serialization happens
         let mut ws_buf = Vec::new();
+        let mut nc = HashMap::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        broadcaster
-            .broadcast_event(node_id("node_1"), event, &event_json, &mut ws_buf)
-            .unwrap();
+        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
 
         let recent = broadcaster.get_recent_events(Some(1));
         assert_eq!(recent.len(), 1);
         let be = &recent[0];
 
-        // serialized_json should be present (we had a subscriber)
         assert!(be.serialized_json.is_some());
         let ws_json: serde_json::Value =
             serde_json::from_str(be.serialized_json.as_ref().unwrap()).unwrap();
         assert_eq!(ws_json["type"], "event");
         assert_eq!(ws_json["data"]["node_id"], "node_1");
 
-        // event_json should be stored on BroadcastEvent
         assert!(be.event_json.is_some());
         assert_eq!(&**be.event_json.as_ref().unwrap(), &*event_json);
     }

--- a/src/event_broadcaster.rs
+++ b/src/event_broadcaster.rs
@@ -27,6 +27,11 @@ const CHANNEL_CLEANUP_INTERVAL: u64 = 30;
 /// Matches BROADCAST_CHANNEL_SIZE to handle the same burst capacity.
 const AGGREGATION_CHANNEL_SIZE: usize = 500_000;
 
+/// Max events per aggregator drain cycle before yielding to tokio.
+/// At 600K events/s this gives ~60 yields/s = yield every ~16ms,
+/// preventing WS loop starvation (observed 700ms stalls without this).
+const AGGREGATOR_DRAIN_LIMIT: usize = 10_000;
+
 /// Broadcast event tuple: (node_id, event, event_json).
 pub type BroadcastRecord = (Arc<str>, Arc<Event>, Arc<[u8]>);
 
@@ -338,17 +343,63 @@ impl EventBroadcaster {
             // Reusable buffer for building WS envelope JSON (avoids per-event allocation)
             let mut ws_buf: Vec<u8> = Vec::with_capacity(4096);
 
+            // Debug stats
+            let mut debug_last_log = tokio::time::Instant::now();
+            let mut debug_events_total = 0u64;
+            let mut debug_drain_max_events = 0u64;
+            let mut debug_drain_max_us = 0u64;
+            let mut debug_drain_count = 0u64;
+
             // Drain all available batches per wakeup for throughput
             while let Some(batch) = receiver.recv().await {
+                let drain_start = tokio::time::Instant::now();
+                let mut drain_events = 0u64;
+
                 for (node_id, event, event_json) in batch.events {
                     let _ = this.broadcast_event(node_id, event, &event_json, &mut ws_buf);
+                    drain_events += 1;
                 }
 
-                // Drain any additional buffered batches without awaiting
-                while let Ok(batch) = receiver.try_recv() {
-                    for (node_id, event, event_json) in batch.events {
-                        let _ = this.broadcast_event(node_id, event, &event_json, &mut ws_buf);
+                // Drain additional buffered batches, but yield after AGGREGATOR_DRAIN_LIMIT
+                // to prevent starving the WS send loop on the same tokio runtime.
+                while (drain_events as usize) < AGGREGATOR_DRAIN_LIMIT {
+                    match receiver.try_recv() {
+                        Ok(batch) => {
+                            for (node_id, event, event_json) in batch.events {
+                                let _ = this.broadcast_event(node_id, event, &event_json, &mut ws_buf);
+                                drain_events += 1;
+                            }
+                        }
+                        Err(_) => break,
                     }
+                }
+
+                let drain_us = drain_start.elapsed().as_micros() as u64;
+                debug_events_total += drain_events;
+                debug_drain_count += 1;
+                if drain_events > debug_drain_max_events {
+                    debug_drain_max_events = drain_events;
+                }
+                if drain_us > debug_drain_max_us {
+                    debug_drain_max_us = drain_us;
+                }
+
+                // Log every 2 seconds
+                if debug_last_log.elapsed() >= std::time::Duration::from_secs(2) {
+                    let elapsed = debug_last_log.elapsed().as_secs_f64();
+                    debug!(
+                        "Aggregator stats: {:.0} events/s, drains={}, max_drain_events={}, max_drain_us={}, mpsc_lag={}",
+                        debug_events_total as f64 / elapsed,
+                        debug_drain_count,
+                        debug_drain_max_events,
+                        debug_drain_max_us,
+                        receiver.len(),
+                    );
+                    debug_events_total = 0;
+                    debug_drain_max_events = 0;
+                    debug_drain_max_us = 0;
+                    debug_drain_count = 0;
+                    debug_last_log = tokio::time::Instant::now();
                 }
             }
             trace!("Aggregator task exiting — all senders dropped");

--- a/src/event_broadcaster.rs
+++ b/src/event_broadcaster.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 /// Size of the main broadcast channel
 /// 500K provides ~5 seconds of buffer at peak throughput (100K events/sec)
@@ -16,12 +16,6 @@ const NODE_CHANNEL_SIZE: usize = 10_000;
 
 /// Maximum number of events to retain in memory for instant replay
 const MAX_RETAINED_EVENTS: usize = 10_000;
-
-/// Maximum number of node-specific channels to maintain
-const MAX_NODE_CHANNELS: usize = 2048;
-
-/// How often to clean up inactive channels (seconds)
-const CHANNEL_CLEANUP_INTERVAL: u64 = 30;
 
 /// Size of the MPSC aggregation channel.
 /// Matches BROADCAST_CHANNEL_SIZE to handle the same burst capacity.
@@ -94,14 +88,6 @@ pub struct BroadcastEvent {
     pub event_json: Option<Arc<[u8]>>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub enum EventFilter {
-    All,
-    Node(String),
-    EventType(u8),
-    EventTypeRange(u8, u8),
-}
-
 /// Statistics for monitoring broadcaster performance
 #[derive(Debug, Serialize)]
 pub struct BroadcasterStats {
@@ -160,16 +146,13 @@ impl EventBroadcaster {
             event_sender,
             event_receiver: Mutex::new(Some(event_receiver)),
             sender,
-            node_channels: Arc::new(RwLock::new(HashMap::with_capacity(MAX_NODE_CHANNELS))),
+            node_channels: Arc::new(RwLock::new(HashMap::with_capacity(1024))),
             recent_events: Arc::new(RwLock::new(VecDeque::with_capacity(MAX_RETAINED_EVENTS))),
             event_counter: Arc::new(AtomicU64::new(0)),
             total_broadcast: Arc::new(AtomicU64::new(0)),
             dropped_events: Arc::new(AtomicU64::new(0)), // Note: Real drops happen inside receivers
             undelivered_events: Arc::new(AtomicU64::new(0)),
         };
-
-        // Start cleanup task for inactive channels
-        broadcaster.start_cleanup_task();
 
         broadcaster
     }
@@ -189,15 +172,20 @@ impl EventBroadcaster {
         let id = self.event_counter.fetch_add(1, Ordering::Relaxed);
 
         let main_receivers = self.sender.receiver_count();
-        let has_node_channels = {
+
+        // Check if anyone is listening on this node's channel
+        let node_has_receivers = {
             let nc = self.node_channels.read();
-            !nc.is_empty()
+            nc.get(&*node_id).map_or(false, |s| s.receiver_count() > 0)
         };
 
-        // Fast path: no WebSocket subscribers and no node-specific channels.
+        // Fast path: no subscribers at all.
         // Still update the ring buffer for API /events catch-up, but skip
         // JSON serialization, broadcast channel send, and node-channel dispatch.
-        if main_receivers == 0 && !has_node_channels {
+        if main_receivers == 0 && !node_has_receivers {
+            // Ensure node channel exists (no send needed — no receivers)
+            self.ensure_node_channel(&node_id);
+
             let broadcast_event = Arc::new(BroadcastEvent {
                 id,
                 node_id,
@@ -218,6 +206,7 @@ impl EventBroadcaster {
                 }
                 recent.push_back(broadcast_event);
             }
+
             return Ok(id);
         }
 
@@ -234,7 +223,8 @@ impl EventBroadcaster {
 
         // Pre-serialize WS envelope using RawValue to avoid re-serializing the Event.
         // The event_json bytes were produced by serde_json::to_vec, so they're valid JSON.
-        if main_receivers > 0 {
+        // Serialize when main channel or node channel has subscribers.
+        if main_receivers > 0 || node_has_receivers {
             // SAFETY: serde_json::to_vec always produces valid UTF-8
             if let Ok(raw_str) = std::str::from_utf8(event_json) {
                 if let Ok(raw_value) = serde_json::value::RawValue::from_string(raw_str.to_string())
@@ -278,13 +268,8 @@ impl EventBroadcaster {
             }
         }
 
-        // Broadcast to node-specific channel if exists (sync read lock - fast path)
-        if has_node_channels {
-            let node_channels = self.node_channels.read();
-            if let Some(sender) = node_channels.get(&*node_id) {
-                let _ = sender.send(broadcast_event.clone());
-            }
-        }
+        // Dispatch to per-node channel (create on first event for this node).
+        self.dispatch_to_node_channel(&node_id, &broadcast_event);
 
         // Add to recent events ring buffer (O(1) operations with VecDeque)
         {
@@ -411,53 +396,39 @@ impl EventBroadcaster {
         self.sender.subscribe()
     }
 
-    /// Subscribe to events from a specific node
-    /// Creates a dedicated channel for this node if it doesn't exist
-    pub fn subscribe_node(&self, node_id: &str) -> broadcast::Receiver<Arc<BroadcastEvent>> {
-        // Check if channel exists (read lock - fast path)
-        {
-            let channels = self.node_channels.read();
-            if let Some(sender) = channels.get(node_id) {
-                return sender.subscribe();
-            }
-        }
-
-        // Channel doesn't exist, need to create it (write lock)
-        let mut channels = self.node_channels.write();
-
-        // Check again in case another task created it
-        if let Some(sender) = channels.get(node_id) {
-            return sender.subscribe();
-        }
-
-        // Enforce maximum channel limit to prevent memory exhaustion
-        if channels.len() >= MAX_NODE_CHANNELS {
-            warn!(
-                "Maximum node channels ({}) reached, using main channel",
-                MAX_NODE_CHANNELS
-            );
-            return self.sender.subscribe();
-        }
-
-        // Create new channel for this node
-        let (tx, rx) = broadcast::channel(NODE_CHANNEL_SIZE);
-        channels.insert(node_id.to_string(), tx);
-
-        info!("Created dedicated channel for node {}", node_id);
-        rx
+    /// Subscribe to a specific node's channel.
+    /// Returns None if node_id hasn't connected yet (no events received).
+    pub fn subscribe_node(&self, node_id: &str) -> Option<broadcast::Receiver<Arc<BroadcastEvent>>> {
+        let channels = self.node_channels.read();
+        channels.get(node_id).map(|sender| sender.subscribe())
     }
 
-    /// Subscribe with a custom filter
-    /// For complex filters, subscribers should use the main channel and filter client-side
-    pub fn subscribe_filtered(
-        &self,
-        filter: EventFilter,
-    ) -> broadcast::Receiver<Arc<BroadcastEvent>> {
-        match filter {
-            EventFilter::All => self.subscribe_all(),
-            EventFilter::Node(node_id) => self.subscribe_node(&node_id),
-            // For other filters, use main channel and filter client-side
-            _ => self.subscribe_all(),
+    /// Subscribe to multiple nodes. Returns receivers keyed by node_id.
+    /// Node IDs that haven't connected yet are silently skipped.
+    pub fn subscribe_nodes(&self, node_ids: &[String]) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
+        let channels = self.node_channels.read();
+        node_ids.iter()
+            .filter_map(|id| channels.get(id).map(|s| (id.clone(), s.subscribe())))
+            .collect()
+    }
+
+    /// Subscribe to all currently-known node channels.
+    /// Returns receivers for every node that has connected.
+    pub fn subscribe_all_nodes(&self) -> Vec<(String, broadcast::Receiver<Arc<BroadcastEvent>>)> {
+        let channels = self.node_channels.read();
+        channels.iter()
+            .map(|(id, sender)| (id.clone(), sender.subscribe()))
+            .collect()
+    }
+
+    /// Remove a node's broadcast channel if no WS clients are subscribed.
+    /// Called when a node's TCP connection drops.
+    pub fn remove_node_channel(&self, node_id: &str) {
+        let mut channels = self.node_channels.write();
+        if let Some(sender) = channels.get(node_id) {
+            if sender.receiver_count() == 0 {
+                channels.remove(node_id);
+            }
         }
     }
 
@@ -509,37 +480,39 @@ impl EventBroadcaster {
         }
     }
 
-    /// Start background task to clean up inactive node channels
-    fn start_cleanup_task(&self) {
-        let node_channels = self.node_channels.clone();
-
-        tokio::spawn(async move {
-            let mut interval =
-                tokio::time::interval(std::time::Duration::from_secs(CHANNEL_CLEANUP_INTERVAL));
-
-            loop {
-                interval.tick().await;
-
-                let mut channels = node_channels.write();
-                let before = channels.len();
-
-                // Remove channels with no receivers
-                channels.retain(|node_id, sender| {
-                    let receiver_count = sender.receiver_count();
-                    if receiver_count == 0 {
-                        debug!("Removing inactive channel for node {}", node_id);
-                        false
-                    } else {
-                        true
-                    }
-                });
-
-                let removed = before - channels.len();
-                if removed > 0 {
-                    info!("Cleaned up {} inactive node channels", removed);
-                }
+    /// Dispatch an event to the per-node broadcast channel, creating it on first use.
+    /// The write-lock path triggers at most once per node (1024 times total over
+    /// the server's lifetime). After that, only the read-lock fast path is taken.
+    fn dispatch_to_node_channel(&self, node_id: &Arc<str>, broadcast_event: &Arc<BroadcastEvent>) {
+        let node_channels = self.node_channels.read();
+        if let Some(sender) = node_channels.get(&**node_id) {
+            let _ = sender.send(broadcast_event.clone());
+        } else {
+            drop(node_channels);
+            let mut nc = self.node_channels.write();
+            // Double-check after acquiring write lock
+            if let Some(sender) = nc.get(&**node_id) {
+                let _ = sender.send(broadcast_event.clone());
+            } else {
+                let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
+                let _ = tx.send(broadcast_event.clone());
+                nc.insert(node_id.to_string(), tx);
             }
-        });
+        }
+    }
+
+    /// Ensure a per-node broadcast channel exists, creating it on first use.
+    fn ensure_node_channel(&self, node_id: &Arc<str>) {
+        let node_channels = self.node_channels.read();
+        if node_channels.contains_key(&**node_id) {
+            return;
+        }
+        drop(node_channels);
+        let mut nc = self.node_channels.write();
+        if !nc.contains_key(&**node_id) {
+            let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
+            nc.insert(node_id.to_string(), tx);
+        }
     }
 }
 
@@ -566,19 +539,27 @@ mod tests {
     #[tokio::test]
     async fn test_broadcaster_scale() {
         let broadcaster = EventBroadcaster::new();
+        let mut ws_buf = Vec::new();
 
-        // Simulate 1024 nodes
-        let mut receivers = Vec::new();
+        // Create channels by broadcasting events for 1024 nodes
         for i in 0..1024 {
-            let rx = broadcaster.subscribe_node(&format!("node_{}", i));
-            receivers.push(rx);
+            let nid = format!("node_{}", i);
+            let event = make_test_event(&nid);
+            let json = make_test_json(&event);
+            broadcaster
+                .broadcast_event(node_id(&nid), event, &json, &mut ws_buf)
+                .unwrap();
         }
 
-        // Verify we can handle the load
-        assert!(receivers.len() == 1024);
+        // Now subscribe to all — channels were created by broadcast_event
+        let receivers: Vec<_> = (0..1024)
+            .filter_map(|i| broadcaster.subscribe_node(&format!("node_{}", i)))
+            .collect();
+
+        assert_eq!(receivers.len(), 1024);
 
         let stats = broadcaster.get_stats();
-        assert!(stats.node_channels <= MAX_NODE_CHANNELS);
+        assert_eq!(stats.node_channels, 1024);
     }
 
     #[tokio::test]
@@ -620,8 +601,17 @@ mod tests {
     #[tokio::test]
     async fn test_subscribe_node_filters() {
         let broadcaster = EventBroadcaster::new();
-        let mut rx_node1 = broadcaster.subscribe_node("node_1");
         let mut ws_buf = Vec::new();
+
+        // Broadcast first to create node_1 channel
+        let setup_event = make_test_event("node_1");
+        let setup_json = make_test_json(&setup_event);
+        broadcaster
+            .broadcast_event(node_id("node_1"), setup_event, &setup_json, &mut ws_buf)
+            .unwrap();
+
+        // Now subscribe to node_1
+        let mut rx_node1 = broadcaster.subscribe_node("node_1").expect("channel should exist");
 
         // Broadcast to node_1 — should be received
         let event1 = make_test_event("node_1");
@@ -647,19 +637,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_subscribe_filtered_all() {
+    async fn test_subscribe_nodes_multi() {
         let broadcaster = EventBroadcaster::new();
-        let mut rx = broadcaster.subscribe_filtered(EventFilter::All);
         let mut ws_buf = Vec::new();
 
-        let event = make_test_event("node_1");
-        let event_json = make_test_json(&event);
-        broadcaster
-            .broadcast_event(node_id("node_1"), event, &event_json, &mut ws_buf)
-            .unwrap();
+        // Create channels by broadcasting
+        for nid in &["node_a", "node_b", "node_c"] {
+            let event = make_test_event(nid);
+            let json = make_test_json(&event);
+            broadcaster
+                .broadcast_event(node_id(nid), event, &json, &mut ws_buf)
+                .unwrap();
+        }
 
-        let received = rx.recv().await.unwrap();
-        assert_eq!(&*received.node_id, "node_1");
+        // Subscribe to node_a and node_b
+        let subs = broadcaster.subscribe_nodes(&["node_a".to_string(), "node_b".to_string()]);
+        assert_eq!(subs.len(), 2);
+
+        // Subscribe to non-existent node — should be skipped
+        let subs2 = broadcaster.subscribe_nodes(&["node_a".to_string(), "nonexistent".to_string()]);
+        assert_eq!(subs2.len(), 1);
+
+        // subscribe_all_nodes should return all 3
+        let all = broadcaster.subscribe_all_nodes();
+        assert_eq!(all.len(), 3);
     }
 
     #[tokio::test]

--- a/src/event_broadcaster.rs
+++ b/src/event_broadcaster.rs
@@ -233,7 +233,7 @@ impl EventBroadcaster {
         let main_receivers = self.sender.receiver_count();
         let node_has_receivers = node_channels
             .get(&*record.node_id)
-            .map_or(false, |s| s.receiver_count() > 0);
+            .is_some_and(|s| s.receiver_count() > 0);
 
         let broadcast_event = Arc::new(BroadcastEvent {
             id: record.id,
@@ -580,7 +580,7 @@ mod tests {
             event_type: event.event_type() as u8,
             timestamp: chrono::Utc::now(),
             ws_json: None,
-            event: event,
+            event,
             event_json: Arc::from(json),
         };
         broadcaster.broadcast_event(record, node_channels);

--- a/src/event_broadcaster.rs
+++ b/src/event_broadcaster.rs
@@ -48,8 +48,18 @@ enum AggregatorCommand {
     },
 }
 
-/// Broadcast event tuple: (node_id, event, event_json).
-pub type BroadcastRecord = (Arc<str>, Arc<Event>, Arc<[u8]>);
+/// Event record produced by ingestion threads with pre-serialized WS JSON.
+/// Sent via MPSC to the aggregator which does pure routing (no serialization).
+pub struct BroadcastRecord {
+    pub node_id: Arc<str>,
+    pub event: Arc<Event>,
+    pub event_json: Arc<[u8]>,
+    pub id: u64,
+    pub event_type: u8,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Pre-serialized WS envelope JSON (built in ingestion thread)
+    pub ws_json: Option<Arc<str>>,
+}
 
 /// Batch of events sent from a connection handler to the aggregator task via MPSC.
 /// One channel message per TCP read wakeup instead of one per event.
@@ -80,19 +90,19 @@ struct WsBroadcastData<'a> {
 /// WsBroadcast variant using pre-serialized Event JSON via RawValue.
 /// Avoids re-serializing the Event enum — the RawValue is embedded verbatim.
 #[derive(Serialize)]
-struct WsBroadcastRaw<'a> {
-    r#type: &'static str,
-    data: WsBroadcastDataRaw<'a>,
-    timestamp: chrono::DateTime<chrono::Utc>,
+pub(crate) struct WsBroadcastRaw<'a> {
+    pub r#type: &'static str,
+    pub data: WsBroadcastDataRaw<'a>,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
 }
 
 /// Inner data payload using RawValue for the pre-serialized Event.
 #[derive(Serialize)]
-struct WsBroadcastDataRaw<'a> {
-    id: u64,
-    node_id: &'a str,
-    event_type: u8,
-    event: &'a serde_json::value::RawValue,
+pub(crate) struct WsBroadcastDataRaw<'a> {
+    pub id: u64,
+    pub node_id: &'a str,
+    pub event_type: u8,
+    pub event: &'a serde_json::value::RawValue,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -119,6 +129,34 @@ pub struct BroadcasterStats {
     pub events_in_buffer: usize,
     pub dropped_events: u64,
     pub undelivered_events: u64, // Events with no subscribers but still in buffer
+}
+
+/// Build the WS envelope JSON from pre-serialized Event JSON.
+/// Uses RawValue to embed the event verbatim (no re-serialization).
+/// `ws_buf` is a reusable buffer owned by the caller (avoids per-event allocation).
+pub(crate) fn build_ws_envelope(
+    id: u64,
+    node_id: &str,
+    event_type: u8,
+    event_json: &[u8],
+    timestamp: chrono::DateTime<chrono::Utc>,
+    ws_buf: &mut Vec<u8>,
+) -> Option<Arc<str>> {
+    let raw_str = std::str::from_utf8(event_json).ok()?;
+    let raw_value = serde_json::value::RawValue::from_string(raw_str.to_string()).ok()?;
+    let ws_response = WsBroadcastRaw {
+        r#type: "event",
+        data: WsBroadcastDataRaw {
+            id,
+            node_id,
+            event_type,
+            event: &raw_value,
+        },
+        timestamp,
+    };
+    ws_buf.clear();
+    serde_json::to_writer(&mut *ws_buf, &ws_response).ok()?;
+    Some(Arc::from(unsafe { std::str::from_utf8_unchecked(ws_buf) }))
 }
 
 /// High-performance event broadcaster designed for 1024+ nodes.
@@ -185,106 +223,44 @@ impl EventBroadcaster {
         }
     }
 
-    /// Broadcast an event to all subscribers.
-    /// Called only from the aggregator task — `node_channels` is the aggregator's local HashMap.
-    /// No locks on the hot path (node_channels is plain HashMap, not behind RwLock).
+    /// Route a pre-built event record to subscribers and ring buffer.
+    /// Called only from the aggregator task — no serialization, pure routing.
     fn broadcast_event(
         &self,
-        node_id: Arc<str>,
-        event: Arc<Event>,
-        event_json: &[u8],
-        ws_buf: &mut Vec<u8>,
+        record: BroadcastRecord,
         node_channels: &mut HashMap<String, broadcast::Sender<Arc<BroadcastEvent>>>,
-    ) -> u64 {
-        let id = self.event_counter.fetch_add(1, Ordering::Relaxed);
-
+    ) {
         let main_receivers = self.sender.receiver_count();
         let node_has_receivers = node_channels
-            .get(&*node_id)
+            .get(&*record.node_id)
             .map_or(false, |s| s.receiver_count() > 0);
 
-        // Fast path: no subscribers at all.
-        if main_receivers == 0 && !node_has_receivers {
-            // Ensure node channel exists for future subscribers
-            if !node_channels.contains_key(&*node_id) {
-                let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
-                node_channels.insert(node_id.to_string(), tx);
-                self.node_channel_count.store(node_channels.len(), Ordering::Relaxed);
-            }
+        let broadcast_event = Arc::new(BroadcastEvent {
+            id: record.id,
+            node_id: record.node_id.clone(),
+            event_type: record.event_type,
+            timestamp: record.timestamp,
+            event: record.event,
+            serialized_json: record.ws_json,
+            event_json: if main_receivers > 0 || node_has_receivers {
+                Some(record.event_json)
+            } else {
+                None
+            },
+        });
 
-            let broadcast_event = Arc::new(BroadcastEvent {
-                id,
-                node_id,
-                event_type: event.event_type() as u8,
-                timestamp: chrono::Utc::now(),
-                event,
-                serialized_json: None,
-                event_json: None,
-            });
-            self.total_broadcast.fetch_add(1, Ordering::Relaxed);
-            self.undelivered_events.fetch_add(1, Ordering::Relaxed);
-
-            {
-                let mut recent = self.recent_events.lock();
-                if recent.len() >= MAX_RETAINED_EVENTS {
-                    recent.pop_front();
-                }
-                recent.push_back(broadcast_event);
-            }
-
-            return id;
-        }
-
-        let event_type = event.event_type() as u8;
-        let mut broadcast_event = BroadcastEvent {
-            id,
-            node_id: node_id.clone(),
-            event_type,
-            timestamp: chrono::Utc::now(),
-            event,
-            serialized_json: None,
-            event_json: Some(Arc::from(event_json)),
-        };
-
-        // Pre-serialize WS envelope using RawValue to avoid re-serializing the Event.
-        if main_receivers > 0 || node_has_receivers {
-            if let Ok(raw_str) = std::str::from_utf8(event_json) {
-                if let Ok(raw_value) = serde_json::value::RawValue::from_string(raw_str.to_string())
-                {
-                    let ws_response = WsBroadcastRaw {
-                        r#type: "event",
-                        data: WsBroadcastDataRaw {
-                            id: broadcast_event.id,
-                            node_id: &broadcast_event.node_id,
-                            event_type: broadcast_event.event_type,
-                            event: &raw_value,
-                        },
-                        timestamp: broadcast_event.timestamp,
-                    };
-                    ws_buf.clear();
-                    if serde_json::to_writer(&mut *ws_buf, &ws_response).is_ok() {
-                        let json_str = unsafe { std::str::from_utf8_unchecked(ws_buf) };
-                        broadcast_event.serialized_json = Some(Arc::from(json_str));
-                    }
-                }
-            }
-        }
-
-        let broadcast_event = Arc::new(broadcast_event);
-
-        // Broadcast to main channel
         if main_receivers > 0 {
             let _ = self.sender.send(broadcast_event.clone());
         }
         self.total_broadcast.fetch_add(1, Ordering::Relaxed);
 
         // Dispatch to per-node channel (create on first event for this node)
-        if let Some(sender) = node_channels.get(&*node_id) {
+        if let Some(sender) = node_channels.get(&*record.node_id) {
             let _ = sender.send(broadcast_event.clone());
         } else {
             let (tx, _) = broadcast::channel(NODE_CHANNEL_SIZE);
             let _ = tx.send(broadcast_event.clone());
-            node_channels.insert(node_id.to_string(), tx);
+            node_channels.insert(record.node_id.to_string(), tx);
             self.node_channel_count.store(node_channels.len(), Ordering::Relaxed);
         }
 
@@ -296,8 +272,6 @@ impl EventBroadcaster {
             }
             recent.push_back(broadcast_event);
         }
-
-        id
     }
 
     /// Submit an event to the aggregation channel for processing.
@@ -310,9 +284,19 @@ impl EventBroadcaster {
     /// is full (backpressure).
     /// Returns `true` if the event was submitted, `false` if the channel is full.
     pub fn send_event(&self, node_id: Arc<str>, event: Arc<Event>, event_json: Arc<[u8]>) -> bool {
+        let id = self.next_event_id();
+        let event_type = event.event_type() as u8;
         self.event_sender
             .try_send(IncomingBatch {
-                events: vec![(node_id, event, event_json)],
+                events: vec![BroadcastRecord {
+                    node_id,
+                    event_type,
+                    id,
+                    timestamp: chrono::Utc::now(),
+                    ws_json: None,
+                    event,
+                    event_json,
+                }],
             })
             .is_ok()
     }
@@ -325,6 +309,12 @@ impl EventBroadcaster {
             return true;
         }
         self.event_sender.try_send(IncomingBatch { events }).is_ok()
+    }
+
+    /// Assign a unique event ID. Called from ingestion threads.
+    /// `fetch_add` is always atomic — `Relaxed` only affects cross-variable ordering.
+    pub fn next_event_id(&self) -> u64 {
+        self.event_counter.fetch_add(1, Ordering::Relaxed)
     }
 
     /// Spawn the aggregator task that drains the MPSC channel and calls `broadcast_event()`.
@@ -348,9 +338,6 @@ impl EventBroadcaster {
         let this = Arc::clone(self);
 
         tokio::spawn(async move {
-            // Reusable buffer for building WS envelope JSON (avoids per-event allocation)
-            let mut ws_buf: Vec<u8> = Vec::with_capacity(4096);
-
             // Node channels owned exclusively by this task — no lock needed
             let mut node_channels: HashMap<String, broadcast::Sender<Arc<BroadcastEvent>>> =
                 HashMap::with_capacity(1024);
@@ -368,8 +355,8 @@ impl EventBroadcaster {
                         let drain_start = tokio::time::Instant::now();
                         let mut drain_events = 0u64;
 
-                        for (node_id, event, event_json) in batch.events {
-                            this.broadcast_event(node_id, event, &event_json, &mut ws_buf, &mut node_channels);
+                        for record in batch.events {
+                            this.broadcast_event(record, &mut node_channels);
                             drain_events += 1;
                         }
 
@@ -377,8 +364,8 @@ impl EventBroadcaster {
                         while (drain_events as usize) < AGGREGATOR_DRAIN_LIMIT {
                             match receiver.try_recv() {
                                 Ok(batch) => {
-                                    for (node_id, event, event_json) in batch.events {
-                                        this.broadcast_event(node_id, event, &event_json, &mut ws_buf, &mut node_channels);
+                                    for record in batch.events {
+                                        this.broadcast_event(record, &mut node_channels);
                                         drain_events += 1;
                                     }
                                 }
@@ -565,10 +552,18 @@ mod tests {
         nid: &str,
         event: Arc<Event>,
         json: &[u8],
-        ws_buf: &mut Vec<u8>,
         node_channels: &mut HashMap<String, broadcast::Sender<Arc<BroadcastEvent>>>,
-    ) -> u64 {
-        broadcaster.broadcast_event(node_id(nid), event, json, ws_buf, node_channels)
+    ) {
+        let record = BroadcastRecord {
+            id: broadcaster.next_event_id(),
+            node_id: node_id(nid),
+            event_type: event.event_type() as u8,
+            timestamp: chrono::Utc::now(),
+            ws_json: None,
+            event: event,
+            event_json: Arc::from(json),
+        };
+        broadcaster.broadcast_event(record, node_channels);
     }
 
     /// Helper: start aggregator and send events via MPSC (for subscribe tests).
@@ -607,13 +602,11 @@ mod tests {
     async fn test_broadcast_and_receive() {
         let broadcaster = EventBroadcaster::new();
         let mut rx = broadcaster.subscribe_all();
-        let mut ws_buf = Vec::new();
         let mut nc = HashMap::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        let id = broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
-        assert_eq!(id, 0);
+        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut nc);
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.id, 0);
@@ -625,12 +618,11 @@ mod tests {
         let broadcaster = EventBroadcaster::new();
         let mut rx1 = broadcaster.subscribe_all();
         let mut rx2 = broadcaster.subscribe_all();
-        let mut ws_buf = Vec::new();
         let mut nc = HashMap::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
+        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut nc);
 
         let e1 = rx1.recv().await.unwrap();
         let e2 = rx2.recv().await.unwrap();
@@ -687,7 +679,6 @@ mod tests {
     #[tokio::test]
     async fn test_recent_events() {
         let broadcaster = EventBroadcaster::new();
-        let mut ws_buf = Vec::new();
         let mut nc = HashMap::new();
 
         // Broadcast 5 events
@@ -695,7 +686,7 @@ mod tests {
             let nid = format!("node_{}", i);
             let event = make_test_event(&nid);
             let event_json = make_test_json(&event);
-            broadcast_direct(&broadcaster, &nid, event, &event_json, &mut ws_buf, &mut nc);
+            broadcast_direct(&broadcaster, &nid, event, &event_json, &mut nc);
         }
 
         // Get last 3
@@ -712,18 +703,17 @@ mod tests {
     #[tokio::test]
     async fn test_recent_events_by_node() {
         let broadcaster = EventBroadcaster::new();
-        let mut ws_buf = Vec::new();
         let mut nc = HashMap::new();
 
         for _ in 0..3 {
             let event = make_test_event("node_a");
             let event_json = make_test_json(&event);
-            broadcast_direct(&broadcaster, "node_a", event, &event_json, &mut ws_buf, &mut nc);
+            broadcast_direct(&broadcaster, "node_a", event, &event_json, &mut nc);
         }
         for _ in 0..2 {
             let event = make_test_event("node_b");
             let event_json = make_test_json(&event);
-            broadcast_direct(&broadcaster, "node_b", event, &event_json, &mut ws_buf, &mut nc);
+            broadcast_direct(&broadcaster, "node_b", event, &event_json, &mut nc);
         }
 
         let node_a_events = broadcaster.get_recent_events_by_node("node_a", 10);
@@ -737,13 +727,12 @@ mod tests {
     #[tokio::test]
     async fn test_recent_events_ring_buffer() {
         let broadcaster = EventBroadcaster::new();
-        let mut ws_buf = Vec::new();
         let mut nc = HashMap::new();
 
         for _ in 0..(MAX_RETAINED_EVENTS + 100) {
             let event = make_test_event("node_1");
             let event_json = make_test_json(&event);
-            broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
+            broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut nc);
         }
 
         let recent = broadcaster.get_recent_events(None);
@@ -755,12 +744,11 @@ mod tests {
     async fn test_get_stats() {
         let broadcaster = EventBroadcaster::new();
         let _rx = broadcaster.subscribe_all();
-        let mut ws_buf = Vec::new();
         let mut nc = HashMap::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
+        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut nc);
 
         let stats = broadcaster.get_stats();
         assert_eq!(stats.total_events_broadcast, 1);
@@ -810,24 +798,40 @@ mod tests {
     #[tokio::test]
     async fn test_broadcast_with_preserialized_json() {
         let broadcaster = EventBroadcaster::new();
-        let _rx = broadcaster.subscribe_all(); // need a subscriber so serialization happens
-        let mut ws_buf = Vec::new();
+        let _rx = broadcaster.subscribe_all(); // need a subscriber so event_json is stored
         let mut nc = HashMap::new();
+        let mut ws_buf = Vec::new();
 
         let event = make_test_event("node_1");
         let event_json = make_test_json(&event);
-        broadcast_direct(&broadcaster, "node_1", event, &event_json, &mut ws_buf, &mut nc);
+        let id = broadcaster.next_event_id();
+        let event_type = event.event_type() as u8;
+        let timestamp = chrono::Utc::now();
+        let ws_json = build_ws_envelope(id, "node_1", event_type, &event_json, timestamp, &mut ws_buf);
+
+        let record = BroadcastRecord {
+            id,
+            node_id: node_id("node_1"),
+            event_type,
+            timestamp,
+            ws_json,
+            event,
+            event_json: Arc::from(&*event_json),
+        };
+        broadcaster.broadcast_event(record, &mut nc);
 
         let recent = broadcaster.get_recent_events(Some(1));
         assert_eq!(recent.len(), 1);
         let be = &recent[0];
 
+        // serialized_json should be present (built by build_ws_envelope)
         assert!(be.serialized_json.is_some());
-        let ws_json: serde_json::Value =
+        let parsed: serde_json::Value =
             serde_json::from_str(be.serialized_json.as_ref().unwrap()).unwrap();
-        assert_eq!(ws_json["type"], "event");
-        assert_eq!(ws_json["data"]["node_id"], "node_1");
+        assert_eq!(parsed["type"], "event");
+        assert_eq!(parsed["data"]["node_id"], "node_1");
 
+        // event_json should be stored (we had a subscriber)
         assert!(be.event_json.is_some());
         assert_eq!(&**be.event_json.as_ref().unwrap(), &*event_json);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,12 @@ struct Cli {
     /// HTTP API bind address
     #[arg(long, env = "API_BIND", default_value = "0.0.0.0:8080")]
     api_bind: String,
+
+    /// Number of dedicated ingestion runtimes for TCP connections.
+    /// Each runtime is a single-thread tokio runtime with its own SO_REUSEPORT listener.
+    /// 0 = legacy single-runtime mode (all tasks on main runtime).
+    #[arg(long, env = "INGESTION_THREADS", default_value_t = 0)]
+    ingestion_threads: usize,
 }
 
 /// Configure TCP socket buffer sizes for better performance.
@@ -182,19 +188,34 @@ async fn main() -> anyhow::Result<()> {
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // Start telemetry server
+    let ingestion_threads = args.ingestion_threads;
     info!("Starting telemetry server on {}", args.telemetry_bind);
     let telemetry_server = Arc::new(
-        TelemetryServer::with_options(&args.telemetry_bind, store.clone(), args.no_rate_limit)
-            .await?,
+        TelemetryServer::with_options(
+            &args.telemetry_bind,
+            store.clone(),
+            args.no_rate_limit,
+            ingestion_threads,
+        )
+        .await?,
     );
-    let telemetry_server_clone = Arc::clone(&telemetry_server);
 
-    // Spawn telemetry server task with shutdown support
-    tokio::spawn(async move {
-        if let Err(e) = telemetry_server_clone.run_until_shutdown(shutdown_rx).await {
-            error!("Telemetry server error: {}", e);
-        }
-    });
+    // Spawn TCP ingestion: either dedicated runtimes (SO_REUSEPORT) or single-runtime
+    let _ingestion_handles = if ingestion_threads > 0 {
+        info!(
+            "Spawning {} dedicated ingestion runtimes (SO_REUSEPORT)",
+            ingestion_threads
+        );
+        Some(telemetry_server.spawn_ingestion_runtimes(ingestion_threads, shutdown_rx))
+    } else {
+        let telemetry_server_clone = Arc::clone(&telemetry_server);
+        tokio::spawn(async move {
+            if let Err(e) = telemetry_server_clone.run_until_shutdown(shutdown_rx).await {
+                error!("Telemetry server error: {}", e);
+            }
+        });
+        None
+    };
 
     // Get the broadcaster from telemetry server for API WebSocket connections
     let broadcaster = telemetry_server.get_broadcaster();
@@ -400,6 +421,11 @@ async fn main() -> anyhow::Result<()> {
 
     info!("=== TART Backend Configuration ===");
     info!("Mode: {}", if store.is_none() { "no-database (WebSocket-only)" } else { "full (DB + WebSocket)" });
+    if ingestion_threads > 0 {
+        info!("Ingestion: {} dedicated runtimes (SO_REUSEPORT)", ingestion_threads);
+    } else {
+        info!("Ingestion: single runtime (legacy)");
+    }
     info!("Max concurrent connections: 1024");
     if !args.no_rate_limit {
         info!("Max events per second per node: 100 (+50 burst)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ struct Cli {
     /// Number of dedicated ingestion runtimes for TCP connections.
     /// Each runtime is a single-thread tokio runtime with its own SO_REUSEPORT listener.
     /// 0 = legacy single-runtime mode (all tasks on main runtime).
-    #[arg(long, env = "INGESTION_THREADS", default_value_t = 0)]
+    #[arg(long, env = "INGESTION_THREADS", default_value_t = 8)]
     ingestion_threads: usize,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,39 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+use clap::Parser;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tart_backend::api::{create_api_router, ApiState};
+use tart_backend::api::{create_api_router, create_minimal_router, ApiState, MinimalApiState};
 use tart_backend::health::{checks, HealthMonitor};
 use tart_backend::jam_rpc::JamRpcClient;
 use tart_backend::{EventStore, TelemetryServer};
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Parser)]
+#[command(name = "tart-backend", about = "TART Telemetry Backend")]
+struct Cli {
+    /// Skip database connection — only broadcast events via WebSocket
+    #[arg(long)]
+    no_database: bool,
+
+    /// Disable rate limiting for incoming events
+    #[arg(long)]
+    no_rate_limit: bool,
+
+    /// Database URL (can also be set via DATABASE_URL env var)
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: Option<String>,
+
+    /// Telemetry TCP bind address
+    #[arg(long, env = "TELEMETRY_BIND", default_value = "0.0.0.0:9000")]
+    telemetry_bind: String,
+
+    /// HTTP API bind address
+    #[arg(long, env = "API_BIND", default_value = "0.0.0.0:8080")]
+    api_bind: String,
+}
 
 /// Configure TCP socket buffer sizes for better performance.
 ///
@@ -123,41 +148,45 @@ async fn main() -> anyhow::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    info!("Starting TART (Testing, Analytics and Research Telemetry) Backend - OPTIMIZED");
-    info!("Optimized for handling up to 1024 concurrent nodes");
+    let args = Cli::parse();
 
-    // Configuration from environment variables
-    let telemetry_bind =
-        std::env::var("TELEMETRY_BIND").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
-    let api_bind = std::env::var("API_BIND").unwrap_or_else(|_| "0.0.0.0:8080".to_string());
-    let database_url = std::env::var("DATABASE_URL").expect(
-        "DATABASE_URL must be set. Example: postgres://user:password@localhost:5432/dbname",
-    );
+    info!("Starting TART (Testing, Analytics and Research Telemetry) Backend");
+    info!("Optimized for handling up to 1024 concurrent nodes");
 
     // Initialize metrics
     let prometheus_handle =
         metrics_exporter_prometheus::PrometheusBuilder::new().install_recorder()?;
 
-    // Initialize optimized storage
-    let redacted_url = match url::Url::parse(&database_url) {
-        Ok(mut parsed) => {
-            if parsed.password().is_some() {
-                let _ = parsed.set_password(Some("***"));
+    // Connect to database (unless --no-database)
+    let store = if args.no_database {
+        info!("NO-DATABASE mode: events will only be broadcast via WebSocket, no DB writes");
+        None
+    } else {
+        let database_url = args.database_url.expect(
+            "DATABASE_URL must be set (--database-url or DATABASE_URL env). Use --no-database to skip.",
+        );
+        let redacted_url = match url::Url::parse(&database_url) {
+            Ok(mut parsed) => {
+                if parsed.password().is_some() {
+                    let _ = parsed.set_password(Some("***"));
+                }
+                parsed.to_string()
             }
-            parsed.to_string()
-        }
-        Err(_) => "***redacted***".to_string(),
+            Err(_) => "***redacted***".to_string(),
+        };
+        info!("Connecting to database: {}", redacted_url);
+        Some(Arc::new(EventStore::new(&database_url).await?))
     };
-    info!("Connecting to database: {}", redacted_url);
-    let store = Arc::new(EventStore::new(&database_url).await?);
 
     // Create shutdown signal for TCP server
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
-    // Start optimized telemetry server
-    info!("Starting optimized telemetry server on {}", telemetry_bind);
-    let telemetry_server =
-        Arc::new(TelemetryServer::new(&telemetry_bind, Arc::clone(&store)).await?);
+    // Start telemetry server
+    info!("Starting telemetry server on {}", args.telemetry_bind);
+    let telemetry_server = Arc::new(
+        TelemetryServer::with_options(&args.telemetry_bind, store.clone(), args.no_rate_limit)
+            .await?,
+    );
     let telemetry_server_clone = Arc::clone(&telemetry_server);
 
     // Spawn telemetry server task with shutdown support
@@ -171,211 +200,220 @@ async fn main() -> anyhow::Result<()> {
     let broadcaster = telemetry_server.get_broadcaster();
     let batch_writer = Arc::new(telemetry_server.get_batch_writer());
 
-    // Initialize health monitoring system
-    info!("Initializing comprehensive health monitoring system");
-    let health_monitor = Arc::new(HealthMonitor::new());
+    // Build the HTTP router: full (with DB) or minimal (WebSocket-only)
+    let mut app = if let Some(ref store) = store {
+        // Initialize health monitoring system
+        info!("Initializing comprehensive health monitoring system");
+        let health_monitor = Arc::new(HealthMonitor::new());
 
-    // Add health checks for all critical components
-    health_monitor
-        .add_check(checks::database_check(Arc::clone(&store)))
-        .await;
-    health_monitor
-        .add_check(checks::batch_writer_check(Arc::clone(&batch_writer)))
-        .await;
-    health_monitor
-        .add_check(checks::broadcaster_check(Arc::clone(&broadcaster)))
-        .await;
-    health_monitor.add_check(checks::memory_check()).await;
-    health_monitor
-        .add_check(checks::system_resources_check())
-        .await;
-    info!("Health monitoring system initialized with 5 critical component checks");
+        health_monitor
+            .add_check(checks::database_check(Arc::clone(store)))
+            .await;
+        health_monitor
+            .add_check(checks::batch_writer_check(Arc::clone(&batch_writer)))
+            .await;
+        health_monitor
+            .add_check(checks::broadcaster_check(Arc::clone(&broadcaster)))
+            .await;
+        health_monitor.add_check(checks::memory_check()).await;
+        health_monitor
+            .add_check(checks::system_resources_check())
+            .await;
+        info!("Health monitoring system initialized with 5 critical component checks");
 
-    // Initialize JAM RPC client if configured
-    let jam_rpc = match std::env::var("JAM_RPC_URL") {
-        Ok(rpc_url) => {
-            info!("Connecting to JAM node RPC at {}", rpc_url);
-            let mut client = JamRpcClient::new(&rpc_url);
-            match client.connect().await {
-                Ok(()) => {
-                    let client = Arc::new(client);
-                    // Start background statistics subscription
-                    let _subscription_handle = client.clone().start_stats_subscription();
-                    info!("JAM RPC client connected and subscribed to statistics");
-                    Some(client)
-                }
-                Err(e) => {
-                    error!("Failed to connect to JAM RPC at {}: {}", rpc_url, e);
-                    info!("JAM RPC endpoints will be unavailable");
-                    None
-                }
-            }
-        }
-        Err(_) => {
-            info!("JAM_RPC_URL not set - JAM RPC endpoints will be unavailable");
-            info!("To enable, set JAM_RPC_URL=ws://localhost:19800");
-            None
-        }
-    };
-
-    // Create TTL cache for expensive analytics queries
-    // 3s TTL with 2s warming interval means data is never more than ~2s old
-    let cache = Arc::new(tart_backend::cache::TtlCache::new(
-        std::time::Duration::from_secs(3),
-    ));
-
-    // Spawn background cache management task:
-    // - Evicts expired entries every ~30 seconds
-    // - Proactively re-warms all cached endpoints every 2 seconds (before the 3s TTL expires)
-    // - Each query is spawned independently and populates its cache key on completion
-    //   (a slow da_stats doesn't block live_counters from being cached)
-    // This means the cache is never cold: the HTTP server starts immediately and the first
-    // user request always hits a warm cache. Slow DB queries happen in the background only.
-    {
-        let cache_clone = Arc::clone(&cache);
-        let store_clone = Arc::clone(&store);
-        tokio::spawn(async move {
-            let mut warm_interval = tokio::time::interval(std::time::Duration::from_secs(2));
-            let mut evict_counter: u64 = 0;
-
-            loop {
-                warm_interval.tick().await;
-                let first = evict_counter == 0;
-
-                if first {
-                    info!("Warming cache with all aggregation endpoints (independent spawns)...");
-                }
-
-                // Spawn each cache-warm query independently. Each populates its cache key
-                // as soon as it completes — no all-or-nothing blocking.
-                // Captures store_clone/cache_clone/first from enclosing scope.
-                macro_rules! spawn_warm {
-                    ($key:expr, $($method:tt)+) => {{
-                        let cache = Arc::clone(&cache_clone);
-                        let store = Arc::clone(&store_clone);
-                        let first = first;
-                        tokio::spawn(async move {
-                            match store.$($method)+.await {
-                                Ok(value) => {
-                                    cache.insert($key.to_string(), value);
-                                    if first {
-                                        info!("Cache warmed: {}", $key);
-                                    }
-                                }
-                                Err(e) => warn!("Cache warm failed for {}: {}", $key, e),
-                            }
-                        })
-                    }};
-                }
-
-                let handles: Vec<tokio::task::JoinHandle<()>> = vec![
-                    spawn_warm!("stats", get_stats("1 hour", "24 hours")),
-                    spawn_warm!("workpackage_stats", get_workpackage_stats("24 hours")),
-                    spawn_warm!("block_stats", get_block_stats("1 hour")),
-                    spawn_warm!("guarantee_stats", get_guarantee_stats("1 hour", "24 hours")),
-                    spawn_warm!("da_stats", get_da_stats()),
-                    spawn_warm!("failure_rates", get_failure_rates("1 hour")),
-                    spawn_warm!("block_propagation", get_block_propagation("1 hour")),
-                    spawn_warm!("network_health", get_network_health("1 hour", "24 hours")),
-                    spawn_warm!(
-                        "guarantees_by_guarantor",
-                        get_guarantees_by_guarantor("1 hour", "24 hours")
-                    ),
-                    spawn_warm!("live_counters", get_live_counters()),
-                    spawn_warm!(
-                        "da_stats_enhanced",
-                        get_da_stats_enhanced("1 hour", "24 hours")
-                    ),
-                    spawn_warm!("execution_metrics", get_execution_metrics("1 hour")),
-                    spawn_warm!("realtime_60", get_realtime_metrics(60)),
-                    spawn_warm!(
-                        "timeseries_throughput_5_1",
-                        get_timeseries_metrics("throughput", 5, 1)
-                    ),
-                ];
-
-                // Anomalies need special handling (wraps Vec<Value> in JSON object)
-                let anomaly_handle = {
-                    let cache = Arc::clone(&cache_clone);
-                    let store = Arc::clone(&store_clone);
-                    tokio::spawn(async move {
-                        match store.detect_anomalies().await {
-                            Ok(alerts) => {
-                                cache.insert(
-                                    "anomalies".to_string(),
-                                    serde_json::json!({"alerts": alerts}),
-                                );
-                                if first {
-                                    info!("Cache warmed: anomalies");
-                                }
-                            }
-                            Err(e) => warn!("Cache warm failed for anomalies: {}", e),
-                        }
-                    })
-                };
-
-                // Await all handles for backpressure (don't start next cycle before current finishes)
-                for handle in handles {
-                    if let Err(e) = handle.await {
-                        warn!("Cache warm task panicked: {}", e);
+        // Initialize JAM RPC client if configured
+        let jam_rpc = match std::env::var("JAM_RPC_URL") {
+            Ok(rpc_url) => {
+                info!("Connecting to JAM node RPC at {}", rpc_url);
+                let mut client = JamRpcClient::new(&rpc_url);
+                match client.connect().await {
+                    Ok(()) => {
+                        let client = Arc::new(client);
+                        let _subscription_handle = client.clone().start_stats_subscription();
+                        info!("JAM RPC client connected and subscribed to statistics");
+                        Some(client)
+                    }
+                    Err(e) => {
+                        error!("Failed to connect to JAM RPC at {}: {}", rpc_url, e);
+                        info!("JAM RPC endpoints will be unavailable");
+                        None
                     }
                 }
-                if let Err(e) = anomaly_handle.await {
-                    warn!("Cache warm task panicked: {}", e);
-                }
-
-                if first {
-                    info!("Initial cache warming complete (15 endpoints, independent spawns)");
-                }
-
-                // Evict expired entries every ~15th cycle (roughly every 30s)
-                evict_counter += 1;
-                if evict_counter.is_multiple_of(15) {
-                    cache_clone.evict_expired();
-                }
             }
-        });
-    }
+            Err(_) => {
+                info!("JAM_RPC_URL not set - JAM RPC endpoints will be unavailable");
+                info!("To enable, set JAM_RPC_URL=ws://localhost:19800");
+                None
+            }
+        };
 
-    // Create API state using the optimized components
-    let api_state = ApiState {
-        store: Arc::clone(&store),
-        telemetry_server,
-        broadcaster,
-        health_monitor,
-        jam_rpc,
-        cache,
+        // Create TTL cache for expensive analytics queries
+        let cache = Arc::new(tart_backend::cache::TtlCache::new(
+            std::time::Duration::from_secs(3),
+        ));
+
+        // Spawn background cache warming task
+        {
+            let cache_clone = Arc::clone(&cache);
+            let store_clone = Arc::clone(store);
+            tokio::spawn(async move {
+                let mut warm_interval =
+                    tokio::time::interval(std::time::Duration::from_secs(2));
+                let mut evict_counter: u64 = 0;
+
+                loop {
+                    warm_interval.tick().await;
+                    let first = evict_counter == 0;
+
+                    if first {
+                        info!("Warming cache with all aggregation endpoints (independent spawns)...");
+                    }
+
+                    macro_rules! spawn_warm {
+                        ($key:expr, $($method:tt)+) => {{
+                            let cache = Arc::clone(&cache_clone);
+                            let store = Arc::clone(&store_clone);
+                            let first = first;
+                            tokio::spawn(async move {
+                                match store.$($method)+.await {
+                                    Ok(value) => {
+                                        cache.insert($key.to_string(), value);
+                                        if first {
+                                            info!("Cache warmed: {}", $key);
+                                        }
+                                    }
+                                    Err(e) => warn!("Cache warm failed for {}: {}", $key, e),
+                                }
+                            })
+                        }};
+                    }
+
+                    let handles: Vec<tokio::task::JoinHandle<()>> = vec![
+                        spawn_warm!("stats", get_stats("1 hour", "24 hours")),
+                        spawn_warm!("workpackage_stats", get_workpackage_stats("24 hours")),
+                        spawn_warm!("block_stats", get_block_stats("1 hour")),
+                        spawn_warm!(
+                            "guarantee_stats",
+                            get_guarantee_stats("1 hour", "24 hours")
+                        ),
+                        spawn_warm!("da_stats", get_da_stats()),
+                        spawn_warm!("failure_rates", get_failure_rates("1 hour")),
+                        spawn_warm!("block_propagation", get_block_propagation("1 hour")),
+                        spawn_warm!(
+                            "network_health",
+                            get_network_health("1 hour", "24 hours")
+                        ),
+                        spawn_warm!(
+                            "guarantees_by_guarantor",
+                            get_guarantees_by_guarantor("1 hour", "24 hours")
+                        ),
+                        spawn_warm!("live_counters", get_live_counters()),
+                        spawn_warm!(
+                            "da_stats_enhanced",
+                            get_da_stats_enhanced("1 hour", "24 hours")
+                        ),
+                        spawn_warm!("execution_metrics", get_execution_metrics("1 hour")),
+                        spawn_warm!("realtime_60", get_realtime_metrics(60)),
+                        spawn_warm!(
+                            "timeseries_throughput_5_1",
+                            get_timeseries_metrics("throughput", 5, 1)
+                        ),
+                    ];
+
+                    let anomaly_handle = {
+                        let cache = Arc::clone(&cache_clone);
+                        let store = Arc::clone(&store_clone);
+                        tokio::spawn(async move {
+                            match store.detect_anomalies().await {
+                                Ok(alerts) => {
+                                    cache.insert(
+                                        "anomalies".to_string(),
+                                        serde_json::json!({"alerts": alerts}),
+                                    );
+                                    if first {
+                                        info!("Cache warmed: anomalies");
+                                    }
+                                }
+                                Err(e) => warn!("Cache warm failed for anomalies: {}", e),
+                            }
+                        })
+                    };
+
+                    for handle in handles {
+                        if let Err(e) = handle.await {
+                            warn!("Cache warm task panicked: {}", e);
+                        }
+                    }
+                    if let Err(e) = anomaly_handle.await {
+                        warn!("Cache warm task panicked: {}", e);
+                    }
+
+                    if first {
+                        info!(
+                            "Initial cache warming complete (15 endpoints, independent spawns)"
+                        );
+                    }
+
+                    evict_counter += 1;
+                    if evict_counter.is_multiple_of(15) {
+                        cache_clone.evict_expired();
+                    }
+                }
+            });
+        }
+
+        let api_state = ApiState {
+            store: Arc::clone(store),
+            telemetry_server,
+            broadcaster,
+            health_monitor,
+            jam_rpc,
+            cache,
+        };
+
+        create_api_router(api_state)
+    } else {
+        // No-database mode: minimal router with WebSocket + health only
+        let minimal_state = MinimalApiState {
+            telemetry_server,
+            broadcaster,
+        };
+
+        create_minimal_router(minimal_state)
     };
 
-    // Create HTTP API router
-    let mut app = create_api_router(api_state);
-
-    // Add metrics endpoint
+    // Add metrics endpoint (always available)
     app = app.route(
         "/metrics",
         axum::routing::get(move || async move { prometheus_handle.render() }),
     );
 
-    // Start HTTP server with optimized settings
-    let api_addr: SocketAddr = api_bind.parse()?;
+    // Start HTTP server
+    let api_addr: SocketAddr = args.api_bind.parse()?;
     info!("Starting HTTP API server on {}", api_addr);
     info!("Metrics available at http://{}/metrics", api_addr);
 
     let listener = tokio::net::TcpListener::bind(api_addr).await?;
 
-    // Configure socket for better performance on Unix
     #[cfg(unix)]
     configure_socket_buffers(&listener);
 
-    info!("=== TART Backend Optimized Configuration ===");
+    info!("=== TART Backend Configuration ===");
+    info!("Mode: {}", if store.is_none() { "no-database (WebSocket-only)" } else { "full (DB + WebSocket)" });
     info!("Max concurrent connections: 1024");
-    info!("Max events per second per node: 100 (+50 burst)");
-    info!("Write batch size: 2000 events");
-    info!("Write batch timeout: 5ms");
-    info!("Cache TTL: 3s, warm interval: 2s (15 endpoints, independent spawns)");
+    if !args.no_rate_limit {
+        info!("Max events per second per node: 100 (+50 burst)");
+    } else {
+        info!("Rate limiting: DISABLED");
+    }
+    if store.is_some() {
+        info!("Write batch size: 16000 events");
+        info!("Write batch timeout: 100ms");
+        info!("Cache TTL: 3s, warm interval: 2s (15 endpoints, independent spawns)");
+    }
     info!("==========================================");
 
-    // Graceful shutdown: flush pending data on SIGTERM/SIGINT
+    // Graceful shutdown
     let batch_writer_shutdown = Arc::clone(&batch_writer);
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,8 +278,7 @@ async fn main() -> anyhow::Result<()> {
             let cache_clone = Arc::clone(&cache);
             let store_clone = Arc::clone(store);
             tokio::spawn(async move {
-                let mut warm_interval =
-                    tokio::time::interval(std::time::Duration::from_secs(2));
+                let mut warm_interval = tokio::time::interval(std::time::Duration::from_secs(2));
                 let mut evict_counter: u64 = 0;
 
                 loop {
@@ -287,7 +286,9 @@ async fn main() -> anyhow::Result<()> {
                     let first = evict_counter == 0;
 
                     if first {
-                        info!("Warming cache with all aggregation endpoints (independent spawns)...");
+                        info!(
+                            "Warming cache with all aggregation endpoints (independent spawns)..."
+                        );
                     }
 
                     macro_rules! spawn_warm {
@@ -313,17 +314,11 @@ async fn main() -> anyhow::Result<()> {
                         spawn_warm!("stats", get_stats("1 hour", "24 hours")),
                         spawn_warm!("workpackage_stats", get_workpackage_stats("24 hours")),
                         spawn_warm!("block_stats", get_block_stats("1 hour")),
-                        spawn_warm!(
-                            "guarantee_stats",
-                            get_guarantee_stats("1 hour", "24 hours")
-                        ),
+                        spawn_warm!("guarantee_stats", get_guarantee_stats("1 hour", "24 hours")),
                         spawn_warm!("da_stats", get_da_stats()),
                         spawn_warm!("failure_rates", get_failure_rates("1 hour")),
                         spawn_warm!("block_propagation", get_block_propagation("1 hour")),
-                        spawn_warm!(
-                            "network_health",
-                            get_network_health("1 hour", "24 hours")
-                        ),
+                        spawn_warm!("network_health", get_network_health("1 hour", "24 hours")),
                         spawn_warm!(
                             "guarantees_by_guarantor",
                             get_guarantees_by_guarantor("1 hour", "24 hours")
@@ -370,9 +365,7 @@ async fn main() -> anyhow::Result<()> {
                     }
 
                     if first {
-                        info!(
-                            "Initial cache warming complete (15 endpoints, independent spawns)"
-                        );
+                        info!("Initial cache warming complete (15 endpoints, independent spawns)");
                     }
 
                     evict_counter += 1;
@@ -420,9 +413,19 @@ async fn main() -> anyhow::Result<()> {
     configure_socket_buffers(&listener);
 
     info!("=== TART Backend Configuration ===");
-    info!("Mode: {}", if store.is_none() { "no-database (WebSocket-only)" } else { "full (DB + WebSocket)" });
+    info!(
+        "Mode: {}",
+        if store.is_none() {
+            "no-database (WebSocket-only)"
+        } else {
+            "full (DB + WebSocket)"
+        }
+    );
     if ingestion_threads > 0 {
-        info!("Ingestion: {} dedicated runtimes (SO_REUSEPORT)", ingestion_threads);
+        info!(
+            "Ingestion: {} dedicated runtimes (SO_REUSEPORT)",
+            ingestion_threads
+        );
     } else {
         info!("Ingestion: single runtime (legacy)");
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,6 @@
 use crate::batch_writer::{BatchWriter, EventRecord};
 use crate::decoder::{decode_message_frame, Decode, DecodingError};
-use crate::event_broadcaster::{BroadcastRecord, EventBroadcaster};
+use crate::event_broadcaster::{build_ws_envelope, BroadcastRecord, EventBroadcaster};
 use crate::events::{Event, NodeInformation};
 use crate::rate_limiter::RateLimiter;
 use crate::store::EventStore;
@@ -594,6 +594,7 @@ async fn handle_connection_optimized(
     // wakeup instead of one per event.
     let mut broadcast_batch: Vec<BroadcastRecord> = Vec::with_capacity(64);
     let mut db_batch: Vec<EventRecord> = Vec::with_capacity(64);
+    let mut ws_buf: Vec<u8> = Vec::with_capacity(4096);
 
     // Read events
     loop {
@@ -631,12 +632,24 @@ async fn handle_connection_optimized(
                                 serde_json::to_vec(&*event).unwrap_or_else(|_| b"{}".to_vec()),
                             );
 
+                            // Build WS envelope in ingestion thread (parallelized across 8 runtimes)
+                            let id = broadcaster.next_event_id();
+                            let event_type = event.event_type() as u8;
+                            let timestamp = chrono::Utc::now();
+                            let ws_json = build_ws_envelope(
+                                id, &node_id_str, event_type, &event_json, timestamp, &mut ws_buf,
+                            );
+
                             // Accumulate for batch send after inner loop
-                            broadcast_batch.push((
-                                node_id_str.clone(),
-                                Arc::clone(&event),
-                                Arc::clone(&event_json),
-                            ));
+                            broadcast_batch.push(BroadcastRecord {
+                                node_id: node_id_str.clone(),
+                                event: Arc::clone(&event),
+                                event_json: Arc::clone(&event_json),
+                                id,
+                                event_type,
+                                timestamp,
+                                ws_json,
+                            });
                             db_batch.push((node_id_str.clone(), event_count, event, event_json));
                             batch_received += 1;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -730,6 +730,7 @@ async fn handle_connection_optimized(
 
     // Clean up
     connections.remove(&*node_id_str);
+    broadcaster.remove_node_channel(&node_id_str);
     let _ = connection_watch.send(connections.len());
     batch_writer.node_disconnected(node_id_str).await?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -94,9 +94,9 @@ pub struct TelemetryServer {
     listener: TcpListener,
     connections: Arc<DashMap<String, NodeConnection>>,
     /// EventStore reference - owned by BatchWriter but kept here for lifetime management
-    /// and potential future direct queries
+    /// and potential future direct queries. None in --no-database mode.
     #[allow(dead_code)]
-    store: Arc<EventStore>,
+    store: Option<Arc<EventStore>>,
     batch_writer: BatchWriter,
     rate_limiter: Arc<RateLimiter>,
     broadcaster: Arc<EventBroadcaster>,
@@ -110,12 +110,12 @@ pub struct TelemetryServer {
 
 impl TelemetryServer {
     pub async fn new(bind_address: &str, store: Arc<EventStore>) -> Result<Self, std::io::Error> {
-        Self::with_options(bind_address, store, false).await
+        Self::with_options(bind_address, Some(store), false).await
     }
 
     pub async fn with_options(
         bind_address: &str,
-        store: Arc<EventStore>,
+        store: Option<Arc<EventStore>>,
         no_rate_limit: bool,
     ) -> Result<Self, std::io::Error> {
         let listener = TcpListener::bind(bind_address).await?;
@@ -142,7 +142,7 @@ impl TelemetryServer {
             "Number of events pending in write buffer"
         );
 
-        let batch_writer = BatchWriter::new(Arc::clone(&store));
+        let batch_writer = BatchWriter::new(store.clone());
 
         if no_rate_limit {
             info!("Rate limiting DISABLED - nodes can send unlimited events");

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,30 @@ use tokio::io::AsyncReadExt;
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, error, info, warn};
 
+/// Create a TCP listener with SO_REUSEPORT enabled using socket2.
+///
+/// Multiple listeners can bind to the same address and the kernel distributes
+/// incoming connections across them. This enables per-runtime accept loops
+/// without a shared listener.
+fn create_reuseport_listener(addr: &SocketAddr) -> Result<std::net::TcpListener, std::io::Error> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::for_address(*addr),
+        socket2::Type::STREAM,
+        Some(socket2::Protocol::TCP),
+    )?;
+    socket.set_reuse_port(true)?;
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+
+    // Set receive buffer to 256KB (matching existing configure_socket_receive_buffer)
+    socket.set_recv_buffer_size(256 * 1024)?;
+
+    socket.bind(&(*addr).into())?;
+    socket.listen(1024)?;
+
+    Ok(socket.into())
+}
+
 /// Configure TCP socket receive buffer size for better performance.
 ///
 /// Sets SO_RCVBUF to 256KB for improved throughput with many concurrent node connections.
@@ -91,7 +115,10 @@ pub struct NodeConnection {
 /// # }
 /// ```
 pub struct TelemetryServer {
-    listener: TcpListener,
+    /// Listener for single-runtime mode. None in multi-runtime (SO_REUSEPORT) mode.
+    listener: Option<TcpListener>,
+    /// Bind address, kept for spawning SO_REUSEPORT listeners in multi-runtime mode.
+    bind_address: SocketAddr,
     connections: Arc<DashMap<String, NodeConnection>>,
     /// EventStore reference - owned by BatchWriter but kept here for lifetime management
     /// and potential future direct queries. None in --no-database mode.
@@ -110,19 +137,42 @@ pub struct TelemetryServer {
 
 impl TelemetryServer {
     pub async fn new(bind_address: &str, store: Arc<EventStore>) -> Result<Self, std::io::Error> {
-        Self::with_options(bind_address, Some(store), false).await
+        Self::with_options(bind_address, Some(store), false, 0).await
     }
 
+    /// Create a new TelemetryServer.
+    ///
+    /// If `ingestion_threads > 0`, the server will NOT bind a listener here — instead,
+    /// `spawn_ingestion_runtimes()` creates N SO_REUSEPORT listeners, each on its own
+    /// single-thread tokio runtime. This eliminates work-stealing contention when handling
+    /// 1024+ TCP connections.
+    ///
+    /// If `ingestion_threads == 0`, behaves as before: single listener on current runtime.
     pub async fn with_options(
         bind_address: &str,
         store: Option<Arc<EventStore>>,
         no_rate_limit: bool,
+        ingestion_threads: usize,
     ) -> Result<Self, std::io::Error> {
-        let listener = TcpListener::bind(bind_address).await?;
-        info!("Telemetry server listening on {}", bind_address);
+        let bind_addr: SocketAddr = bind_address.parse().map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("bad address: {e}"))
+        })?;
 
-        #[cfg(unix)]
-        configure_socket_receive_buffer(&listener);
+        let listener = if ingestion_threads == 0 {
+            let listener = TcpListener::bind(bind_addr).await?;
+            info!("Telemetry server listening on {}", bind_address);
+
+            #[cfg(unix)]
+            configure_socket_receive_buffer(&listener);
+
+            Some(listener)
+        } else {
+            info!(
+                "Telemetry server will use {} dedicated ingestion runtimes on {}",
+                ingestion_threads, bind_address
+            );
+            None
+        };
 
         // Initialize metrics
         metrics::describe_counter!(
@@ -155,6 +205,7 @@ impl TelemetryServer {
 
         Ok(Self {
             listener,
+            bind_address: bind_addr,
             connections: Arc::new(DashMap::new()),
             batch_writer,
             rate_limiter: Arc::new(RateLimiter::new()),
@@ -167,8 +218,9 @@ impl TelemetryServer {
     }
 
     pub async fn run(&self) -> Result<(), std::io::Error> {
+        let listener = self.listener.as_ref().expect("run() requires single-runtime mode (ingestion_threads=0)");
         loop {
-            match self.listener.accept().await {
+            match listener.accept().await {
                 Ok((stream, addr)) => {
                     self.spawn_connection(stream, addr);
                 }
@@ -179,14 +231,15 @@ impl TelemetryServer {
         }
     }
 
-    /// Run the server until a shutdown signal is received.
+    /// Run the server until a shutdown signal is received (single-runtime mode).
     pub async fn run_until_shutdown(
         &self,
         mut shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<(), std::io::Error> {
+        let listener = self.listener.as_ref().expect("run_until_shutdown() requires single-runtime mode (ingestion_threads=0)");
         loop {
             tokio::select! {
-                result = self.listener.accept() => {
+                result = listener.accept() => {
                     match result {
                         Ok((stream, addr)) => {
                             self.spawn_connection(stream, addr);
@@ -203,6 +256,107 @@ impl TelemetryServer {
             }
         }
         Ok(())
+    }
+
+    /// Spawn N dedicated ingestion runtimes, each with its own SO_REUSEPORT listener.
+    ///
+    /// Each runtime is a single-thread tokio runtime running on its own OS thread.
+    /// The kernel distributes incoming TCP connections across the listeners.
+    /// Returns the join handles for the OS threads (for shutdown coordination).
+    pub fn spawn_ingestion_runtimes(
+        &self,
+        n: usize,
+        shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> Vec<std::thread::JoinHandle<()>> {
+        let mut handles = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let bind_addr = self.bind_address;
+            let mut shutdown = shutdown.clone();
+            let connections = Arc::clone(&self.connections);
+            let batch_writer = self.batch_writer.clone();
+            let rate_limiter = Arc::clone(&self.rate_limiter);
+            let broadcaster = Arc::clone(&self.broadcaster);
+            let rate_limit_disabled = self.rate_limit_disabled;
+            let connection_watch = Arc::clone(&self.connection_watch);
+
+            let handle = std::thread::Builder::new()
+                .name(format!("ingestion-{i}"))
+                .spawn(move || {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .unwrap_or_else(|e| panic!("ingestion runtime {i}: {e}"));
+
+                    rt.block_on(async move {
+                        let std_listener = match create_reuseport_listener(&bind_addr) {
+                            Ok(l) => l,
+                            Err(e) => {
+                                error!("ingestion-{i}: failed to bind {bind_addr}: {e}");
+                                return;
+                            }
+                        };
+
+                        let listener = TcpListener::from_std(std_listener)
+                            .expect("ingestion: TcpListener::from_std");
+
+                        info!("ingestion-{i}: listening on {bind_addr} (SO_REUSEPORT)");
+
+                        loop {
+                            tokio::select! {
+                                result = listener.accept() => {
+                                    match result {
+                                        Ok((stream, addr)) => {
+                                            // Check connection limit
+                                            if !rate_limiter.allow_connection(&addr) {
+                                                drop(stream);
+                                                continue;
+                                            }
+
+                                            info!(
+                                                "New connection from {} ({}/{})",
+                                                addr,
+                                                rate_limiter.connection_count(),
+                                                crate::rate_limiter::MAX_CONNECTIONS
+                                            );
+
+                                            let rl = Arc::clone(&rate_limiter);
+                                            let ctx = ConnectionContext {
+                                                connections: Arc::clone(&connections),
+                                                batch_writer: batch_writer.clone(),
+                                                rate_limiter: rl.clone(),
+                                                broadcaster: Arc::clone(&broadcaster),
+                                                rate_limit_disabled,
+                                                connection_watch: Arc::clone(&connection_watch),
+                                            };
+
+                                            tokio::spawn(async move {
+                                                let result = handle_connection_optimized(stream, addr, ctx).await;
+                                                rl.connection_closed();
+                                                if let Err(e) = result {
+                                                    error!("Connection error from {}: {}", addr, e);
+                                                }
+                                            });
+                                        }
+                                        Err(e) => {
+                                            error!("ingestion-{i}: accept error: {e}");
+                                        }
+                                    }
+                                }
+                                _ = shutdown.changed() => {
+                                    info!("ingestion-{i}: shutdown signal received");
+                                    break;
+                                }
+                            }
+                        }
+                    });
+                })
+                .unwrap_or_else(|e| panic!("failed to spawn ingestion thread {i}: {e}"));
+
+            handles.push(handle);
+        }
+
+        handles
     }
 
     fn spawn_connection(&self, stream: TcpStream, addr: SocketAddr) {
@@ -294,7 +448,10 @@ impl TelemetryServer {
     ///
     /// Useful in tests that bind to port 0 to discover the assigned port.
     pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
-        self.listener.local_addr()
+        match &self.listener {
+            Some(listener) => listener.local_addr(),
+            None => Ok(self.bind_address),
+        }
     }
 
     pub async fn flush_writes(&self) -> anyhow::Result<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -155,7 +155,10 @@ impl TelemetryServer {
         ingestion_threads: usize,
     ) -> Result<Self, std::io::Error> {
         let bind_addr: SocketAddr = bind_address.parse().map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("bad address: {e}"))
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("bad address: {e}"),
+            )
         })?;
 
         let listener = if ingestion_threads == 0 {
@@ -218,7 +221,10 @@ impl TelemetryServer {
     }
 
     pub async fn run(&self) -> Result<(), std::io::Error> {
-        let listener = self.listener.as_ref().expect("run() requires single-runtime mode (ingestion_threads=0)");
+        let listener = self
+            .listener
+            .as_ref()
+            .expect("run() requires single-runtime mode (ingestion_threads=0)");
         loop {
             match listener.accept().await {
                 Ok((stream, addr)) => {
@@ -236,7 +242,10 @@ impl TelemetryServer {
         &self,
         mut shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<(), std::io::Error> {
-        let listener = self.listener.as_ref().expect("run_until_shutdown() requires single-runtime mode (ingestion_threads=0)");
+        let listener = self
+            .listener
+            .as_ref()
+            .expect("run_until_shutdown() requires single-runtime mode (ingestion_threads=0)");
         loop {
             tokio::select! {
                 result = listener.accept() => {
@@ -637,7 +646,12 @@ async fn handle_connection_optimized(
                             let event_type = event.event_type() as u8;
                             let timestamp = chrono::Utc::now();
                             let ws_json = build_ws_envelope(
-                                id, &node_id_str, event_type, &event_json, timestamp, &mut ws_buf,
+                                id,
+                                &node_id_str,
+                                event_type,
+                                &event_json,
+                                timestamp,
+                                &mut ws_buf,
                             );
 
                             // Accumulate for batch send after inner loop

--- a/src/server.rs
+++ b/src/server.rs
@@ -730,7 +730,7 @@ async fn handle_connection_optimized(
 
     // Clean up
     connections.remove(&*node_id_str);
-    broadcaster.remove_node_channel(&node_id_str);
+    broadcaster.remove_node_channel(&node_id_str).await;
     let _ = connection_watch.send(connections.len());
     batch_writer.node_disconnected(node_id_str).await?;
 

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -27,7 +27,7 @@ async fn setup_test_api() -> (TestServer, Arc<TelemetryServer>, u16) {
         .expect("Failed to cleanup test data");
 
     let telemetry_server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", Arc::clone(&store), true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(Arc::clone(&store)), true)
             .await
             .unwrap(),
     );

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -27,7 +27,7 @@ async fn setup_test_api() -> (TestServer, Arc<TelemetryServer>, u16) {
         .expect("Failed to cleanup test data");
 
     let telemetry_server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", Some(Arc::clone(&store)), true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(Arc::clone(&store)), true, 0)
             .await
             .unwrap(),
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18,7 +18,7 @@ async fn setup_test_server() -> (Arc<TelemetryServer>, u16) {
     let _ = store.cleanup_test_data().await;
 
     let server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", Some(store), true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(store), true, 0)
             .await
             .unwrap(),
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18,7 +18,7 @@ async fn setup_test_server() -> (Arc<TelemetryServer>, u16) {
     let _ = store.cleanup_test_data().await;
 
     let server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", store, true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(store), true)
             .await
             .unwrap(),
     );

--- a/tests/optimized_server_tests.rs
+++ b/tests/optimized_server_tests.rs
@@ -18,7 +18,7 @@ async fn setup_optimized_test_server() -> (Arc<TelemetryServer>, u16) {
     let _ = store.cleanup_test_data().await;
 
     let server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", store, true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(store), true)
             .await
             .unwrap(),
     );

--- a/tests/optimized_server_tests.rs
+++ b/tests/optimized_server_tests.rs
@@ -18,7 +18,7 @@ async fn setup_optimized_test_server() -> (Arc<TelemetryServer>, u16) {
     let _ = store.cleanup_test_data().await;
 
     let server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", Some(store), true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(store), true, 0)
             .await
             .unwrap(),
     );

--- a/tests/ws_tests.rs
+++ b/tests/ws_tests.rs
@@ -26,7 +26,7 @@ async fn setup_ws_test() -> (String, Arc<TelemetryServer>, u16) {
         .expect("Failed to cleanup test data");
 
     let telemetry_server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", Arc::clone(&store), true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(Arc::clone(&store)), true)
             .await
             .unwrap(),
     );

--- a/tests/ws_tests.rs
+++ b/tests/ws_tests.rs
@@ -26,7 +26,7 @@ async fn setup_ws_test() -> (String, Arc<TelemetryServer>, u16) {
         .expect("Failed to cleanup test data");
 
     let telemetry_server = Arc::new(
-        TelemetryServer::with_options("127.0.0.1:0", Some(Arc::clone(&store)), true)
+        TelemetryServer::with_options("127.0.0.1:0", Some(Arc::clone(&store)), true, 0)
             .await
             .unwrap(),
     );


### PR DESCRIPTION
### Breaking WS API changes

**Subscribe filter `Node` → `Nodes`:**

```json
// Before — single node only
{"type":"Subscribe","filter":{"type":"Node","node_id":"abc123"}}

// After — single node
{"type":"Subscribe","filter":{"type":"Nodes","node_ids":["abc123"]}}

// After — multiple nodes
{"type":"Subscribe","filter":{"type":"Nodes","node_ids":["abc123","def456"]}}

// After — all events  (recommended, main broadcast channel, )
{"type":"Subscribe","filter":{"type":"All"}}

// After — all node channels (wildcard, for StreamMap perf evaluation)
{"type":"Subscribe","filter":{"type":"Nodes","node_ids":["*"]}}
```

**New `batch` message type:**

Events are now can batched — up to 100 per WS frame:
```json
{"type":"batch","data":[{event1},{event2},...],"timestamp":"2025-..."}
```
Single events still sent unwrapped as `{"type":"event",...}`. Clients must handle both.

**`--no-database` mode:**

Minimal `/api/ws` + `/api/health` router for WS-only streaming without a DB. Stats/metrics/alerts disabled. Mainly for streaming performance evaluation.

### Optimizations
#### WS sender: Lagged handling

Previously, a `RecvError::Lagged` from the broadcast channel killed the WS connection — the client had to reconnect and lost all context. Now lagged events are counted and skipped, the connection stays alive, and the client keeps receiving. Debug logs report `lagged_total` so slow clients are visible without being punished.

#### WS sender: opportunistic batching

After receiving one event, the WS handler drains up to 100 more via `try_recv()` (non-blocking) and sends them in a single frame. Measured 1.6M ev/s vs 158K unbatched. Also helps drain `broadcast_lag` spikes faster (observed up to 524K with batch=10).

#### Dedicated ingestion runtimes (default: 8)
With a single tokio runtime, 1024 TCP ingestion tasks starved WS client tasks — the WS sender couldn't get scheduled often enough to drain its broadcast receiver, causing `broadcast_lag` to climb and events to be lost. Ingestion now runs on 8 dedicated single-thread tokio runtimes (`--ingestion-threads`, `SO_REUSEPORT`), freeing the main runtime for WS clients, API, and the aggregator.

#### Aggregator bottleneck fixes

Three bottlenecks were hit at 600K+ events/s with WS subscribers connected:

1. **Lock contention on node_channels HashMap** — `broadcast_event()` took a write lock on `RwLock<HashMap>` for every event. Replaced with actor pattern: aggregator owns the HashMap, WS handlers send commands via mpsc with oneshot replies. Lock removed entirely.

2. **Aggregator busy-loop** — `try_recv()` in a tight loop burned CPU when idle. Replaced with `select!` over batch channel + command channel.

3. **JSON serialization in single aggregator** — Building WS envelopes (RawValue parse + serde) for every event at 600K/s caused `mpsc_lag` to grow to 272K — aggregator couldn't keep up. Moved serialization to the 8 ingestion runtimes (~75K ev/s each). Aggregator now does pure routing. Result: `mpsc_lag` stays at 0.

