### PR TITLE
migrations: keep core dimension in wp_pipeline aggregates

### DIFF
--- a/migrations/002_count_tables.sql
+++ b/migrations/002_count_tables.sql
@@ -114,9 +114,6 @@ CREATE TABLE wp_pipeline_counts (
 SELECT create_hypertable('wp_pipeline_counts', 'bucket', chunk_time_interval => INTERVAL '1 day');
 ALTER TABLE wp_pipeline_counts ADD CHECK (event_type BETWEEN 90 AND 105);
 CREATE INDEX ON wp_pipeline_counts (node_id, event_type, bucket DESC);
--- all_core_stats_1m queries raw tables with core filter (partial: many rows have NULL core)
-CREATE INDEX IF NOT EXISTS idx_wp_pipeline_counts_core
-    ON wp_pipeline_counts (core, event_type, bucket DESC) WHERE core IS NOT NULL;
 ALTER TABLE wp_pipeline_counts SET (
     timescaledb.compress,
     timescaledb.compress_segmentby = 'node_id, event_type',
@@ -184,9 +181,6 @@ CREATE TABLE guarantee_sending_counts (
 SELECT create_hypertable('guarantee_sending_counts', 'bucket', chunk_time_interval => INTERVAL '1 day');
 ALTER TABLE guarantee_sending_counts ADD CHECK (event_type BETWEEN 106 AND 109);
 CREATE INDEX ON guarantee_sending_counts (node_id, event_type, bucket DESC);
--- all_core_stats_1m queries raw tables with core filter (partial: many rows have NULL core)
-CREATE INDEX IF NOT EXISTS idx_guarantee_sending_counts_core
-    ON guarantee_sending_counts (core, event_type, bucket DESC) WHERE core IS NOT NULL;
 ALTER TABLE guarantee_sending_counts SET (
     timescaledb.compress,
     timescaledb.compress_segmentby = 'node_id, event_type',
@@ -298,9 +292,6 @@ CREATE TABLE segment_counts (
 SELECT create_hypertable('segment_counts', 'bucket', chunk_time_interval => INTERVAL '1 day');
 ALTER TABLE segment_counts ADD CHECK (event_type BETWEEN 160 AND 178);
 CREATE INDEX ON segment_counts (node_id, event_type, bucket DESC);
--- all_core_stats_1m queries raw tables with core filter (partial: many rows have NULL core)
-CREATE INDEX IF NOT EXISTS idx_segment_counts_core
-    ON segment_counts (core, event_type, bucket DESC) WHERE core IS NOT NULL;
 ALTER TABLE segment_counts SET (
     timescaledb.compress,
     timescaledb.compress_segmentby = 'node_id, event_type',

--- a/migrations/003_count_aggregates.sql
+++ b/migrations/003_count_aggregates.sql
@@ -1,6 +1,7 @@
 -- Hierarchical continuous aggregates over the count tables:
 -- <group>_1m (from raw, 30d retention) and <group>_1h (from _1m, 365d retention).
--- guarantee_sending and segment aggregates keep the `core` dimension.
+-- guarantee_sending, segment, and wp_pipeline aggregates keep the `core`
+-- dimension (all_core_stats_1m reads them).
 
 -- ============================================================
 -- block_distribution_counts
@@ -464,10 +465,10 @@ CREATE MATERIALIZED VIEW wp_pipeline_counts_1m
 WITH (timescaledb.continuous) AS
 SELECT
     time_bucket('1 minute', bucket) AS bucket,
-    node_id, event_type,
+    node_id, event_type, core,
     SUM(event_count) AS event_count
 FROM wp_pipeline_counts
-GROUP BY 1, node_id, event_type
+GROUP BY 1, node_id, event_type, core
 WITH NO DATA;
 
 SELECT add_continuous_aggregate_policy('wp_pipeline_counts_1m',
@@ -480,10 +481,10 @@ CREATE MATERIALIZED VIEW wp_pipeline_counts_1h
 WITH (timescaledb.continuous) AS
 SELECT
     time_bucket('1 hour', bucket) AS bucket,
-    node_id, event_type,
+    node_id, event_type, core,
     SUM(event_count) AS event_count
 FROM wp_pipeline_counts_1m
-GROUP BY 1, node_id, event_type
+GROUP BY 1, node_id, event_type, core
 WITH NO DATA;
 
 SELECT add_continuous_aggregate_policy('wp_pipeline_counts_1h',
@@ -593,3 +594,11 @@ CREATE INDEX IF NOT EXISTS idx_wp_pipeline_counts_1m_et
     ON wp_pipeline_counts_1m (event_type, bucket DESC);
 CREATE INDEX IF NOT EXISTS idx_wp_pipeline_counts_1h_et
     ON wp_pipeline_counts_1h (event_type, bucket DESC);
+
+-- all_core_stats_1m filters these aggregates by core (partial: NULL-core rows excluded)
+CREATE INDEX IF NOT EXISTS idx_guarantee_sending_counts_1m_core
+    ON guarantee_sending_counts_1m (core, event_type, bucket DESC) WHERE core IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_segment_counts_1m_core
+    ON segment_counts_1m (core, event_type, bucket DESC) WHERE core IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_wp_pipeline_counts_1m_core
+    ON wp_pipeline_counts_1m (core, event_type, bucket DESC) WHERE core IS NOT NULL;

--- a/migrations/004_union_views.sql
+++ b/migrations/004_union_views.sql
@@ -52,14 +52,13 @@ CREATE VIEW all_event_stats_1h AS
   UNION ALL SELECT bucket, node_id, event_type, event_count FROM segment_counts_1h
   UNION ALL SELECT bucket, node_id, event_type, event_count FROM preimage_counts_1h;
 
--- Core-aware UNION view (for timeseries?group_by=core and core=X filter)
--- Only tables with a core column participate.
--- Uses raw count tables (not _1m aggregates) because the continuous aggregates
--- with node_id GROUP BY would double-count; the raw tables carry core directly.
+-- Core-aware UNION view (for timeseries?group_by=core and core=X filter).
+-- Only the three groups carrying a core dimension participate. Reads the
+-- _1m aggregates, so core queries get their 30-day retention.
 CREATE VIEW all_core_stats_1m AS
   SELECT bucket, event_type, core, event_count
-    FROM guarantee_sending_counts WHERE core IS NOT NULL
+    FROM guarantee_sending_counts_1m WHERE core IS NOT NULL
   UNION ALL SELECT bucket, event_type, core, event_count
-    FROM segment_counts WHERE core IS NOT NULL
+    FROM segment_counts_1m WHERE core IS NOT NULL
   UNION ALL SELECT bucket, event_type, core, event_count
-    FROM wp_pipeline_counts WHERE core IS NOT NULL;
+    FROM wp_pipeline_counts_1m WHERE core IS NOT NULL;


### PR DESCRIPTION
The raw `wp_pipeline_counts` table always carried `core`, but the `_1m/_1h` aggregates dropped it in their GROUP BY, forcing `all_core_stats_1m` to read the raw tables — capping core-scoped Grafana queries at the 3-day raw retention while node queries reach a year.

Add core to wp_pipeline_counts_1m/_1h and repoint all_core_stats_1m at the three _1m aggregates: core panels now get 30-day reach. The partial core indexes move from the raw tables (no longer queried by core) to the _1m aggregates the view scans.