### PR TITLE
tests: make `Event::Encode` match the `JIP-3` wire format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0"
 utoipa = { version = "5", features = ["axum_extras", "chrono"] }
 serde_bytes = "0.11"
 bytes = "1.7"
+jam-codec = "0.1.1"
 
 # Error handling
 thiserror = "1.0"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -142,40 +142,20 @@ impl Decode for Vec<u8> {
     }
 }
 
+// Graypaper general natural number serialization, via the same crate real nodes use.
 pub fn decode_variable_length(buf: &mut Cursor<&[u8]>) -> Result<u64, DecodingError> {
-    let mut value = 0u64;
-    let mut shift = 0;
     let start_pos = buf.position();
     let available = buf.remaining();
 
-    loop {
-        if buf.remaining() < 1 {
-            return Err(DecodingError::InsufficientData {
+    let mut input = &buf.get_ref()[start_pos as usize..];
+    let jam_codec::Compact(value) =
+        <jam_codec::Compact<u64> as jam_codec::Decode>::decode(&mut input).map_err(|_| {
+            DecodingError::InsufficientData {
                 needed: 1,
-                available: buf.remaining(),
-            });
-        }
-
-        let byte = buf.get_u8();
-        value |= ((byte & 0x7F) as u64) << shift;
-
-        if byte & 0x80 == 0 {
-            break;
-        }
-
-        shift += 7;
-        if shift >= 64 {
-            return Err(DecodingError::InvalidDiscriminator(byte));
-        }
-
-        // Sanity check: if we've read more than 9 bytes for a u64, something is wrong
-        if buf.position() - start_pos > 9 {
-            let data_slice = &buf.get_ref()[start_pos as usize..];
-            tracing::warn!("Variable length decode reading too many bytes. Available: {}, Value so far: {}, Data: {}", 
-                available, value, hex_dump(data_slice, 20));
-            return Err(DecodingError::InvalidDiscriminator(byte));
-        }
-    }
+                available,
+            }
+        })?;
+    buf.set_position((buf.get_ref().len() - input.len()) as u64);
 
     // Additional sanity check for unreasonable values
     if value > 1_000_000 {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -142,30 +142,14 @@ impl<T: Encode> Encode for Vec<T> {
     }
 }
 
-pub fn encode_variable_length(mut value: u64, buf: &mut BytesMut) -> Result<(), EncodingError> {
-    loop {
-        let byte = (value & 0x7F) as u8;
-        value >>= 7;
-        if value == 0 {
-            buf.put_u8(byte);
-            break;
-        } else {
-            buf.put_u8(byte | 0x80);
-        }
-    }
+// Graypaper general natural number serialization, via the same crate real nodes use.
+pub fn encode_variable_length(value: u64, buf: &mut BytesMut) -> Result<(), EncodingError> {
+    buf.extend_from_slice(&jam_codec::Encode::encode(&jam_codec::Compact(value)));
     Ok(())
 }
 
-pub fn variable_length_size(mut value: u64) -> usize {
-    let mut size = 0;
-    loop {
-        size += 1;
-        value >>= 7;
-        if value == 0 {
-            break;
-        }
-    }
-    size
+pub fn variable_length_size(value: u64) -> usize {
+    <jam_codec::Compact<u64> as jam_codec::CompactLen<u64>>::compact_len(&value)
 }
 
 pub fn encode_message<T: Encode>(msg: &T) -> Result<Vec<u8>, EncodingError> {

--- a/src/events.rs
+++ b/src/events.rs
@@ -1646,7 +1646,9 @@ impl Encode for Event {
                 submission_or_share_id.encode(buf)?;
                 reason.encode(buf)?;
             }
-            Event::WorkPackageSubmission { builder, bundle, .. } => {
+            Event::WorkPackageSubmission {
+                builder, bundle, ..
+            } => {
                 builder.encode(buf)?;
                 bundle.encode(buf)?;
             }
@@ -1676,7 +1678,9 @@ impl Encode for Event {
                 submission_or_share_id.encode(buf)?;
             }
             Event::SharingWorkPackage {
-                submission_id, secondary, ..
+                submission_id,
+                secondary,
+                ..
             } => {
                 submission_id.encode(buf)?;
                 secondary.encode(buf)?;
@@ -1692,7 +1696,9 @@ impl Encode for Event {
                 reason.encode(buf)?;
             }
             Event::BundleSent {
-                submission_id, secondary, ..
+                submission_id,
+                secondary,
+                ..
             } => {
                 submission_id.encode(buf)?;
                 secondary.encode(buf)?;
@@ -1701,7 +1707,9 @@ impl Encode for Event {
                 share_id.encode(buf)?;
             }
             Event::WorkReportSignatureReceived {
-                submission_id, secondary, ..
+                submission_id,
+                secondary,
+                ..
             } => {
                 submission_id.encode(buf)?;
                 secondary.encode(buf)?;
@@ -2164,14 +2172,14 @@ impl Encode for Event {
             Event::GuaranteesDistributed { .. } => 8, // submission_id only
             Event::WorkPackageFailed { reason, .. } => 8 + reason.encoded_size(),
             Event::WorkPackageSubmission { .. } => 32 + 1, // builder + bundle
-            Event::WorkPackageBeingShared { .. } => 32,     // primary
+            Event::WorkPackageBeingShared { .. } => 32,    // primary
             Event::DuplicateWorkPackage { .. } => 8 + 2 + 32, // submission_or_share_id + core + hash
-            Event::ExtrinsicDataReceived { .. } => 8,       // submission_or_share_id
-            Event::ImportsReceived { .. } => 8,             // submission_or_share_id
-            Event::SharingWorkPackage { .. } => 8 + 32,     // submission_id + secondary
+            Event::ExtrinsicDataReceived { .. } => 8,         // submission_or_share_id
+            Event::ImportsReceived { .. } => 8,               // submission_or_share_id
+            Event::SharingWorkPackage { .. } => 8 + 32,       // submission_id + secondary
             Event::WorkPackageSharingFailed { reason, .. } => 8 + 32 + reason.encoded_size(),
-            Event::BundleSent { .. } => 8 + 32,             // submission_id + secondary
-            Event::WorkReportSignatureSent { .. } => 8,     // share_id
+            Event::BundleSent { .. } => 8 + 32, // submission_id + secondary
+            Event::WorkReportSignatureSent { .. } => 8, // share_id
             Event::WorkReportSignatureReceived { .. } => 8 + 32, // submission_id + secondary
             // Guarantee sending (106-108)
             Event::SendingGuarantee { .. } => 8 + 32, // built_id + recipient
@@ -2218,7 +2226,8 @@ impl Encode for Event {
             // Segment fetching (162-178) — SegmentsRootMapped handled elsewhere
             Event::SegmentsRootMapped { .. } => 8 + 32 + 32, // submission_id + segments_root + erasure_root
             Event::SendingSegmentShardRequest { shards, .. } => {
-                8 + 32 + 1 + variable_length_size(shards.len() as u64) + shards.len() * 4 // proofs + len + pairs
+                8 + 32 + 1 + variable_length_size(shards.len() as u64) + shards.len() * 4
+                // proofs + len + pairs
             }
             Event::ReceivingSegmentShardRequest { .. } => 32 + 1, // sender + proofs
             Event::SegmentShardRequestFailed { reason, .. } => 8 + reason.encoded_size(),

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,7 +1,7 @@
 //! Telemetry event type definitions and protocol version constants. Each variant
 //! of `Event` corresponds to a distinct telemetry message emitted by JAM nodes.
 
-use crate::encoding::{Encode, EncodingError};
+use crate::encoding::{encode_variable_length, variable_length_size, Encode, EncodingError};
 use crate::types::*;
 use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
@@ -1646,6 +1646,66 @@ impl Encode for Event {
                 submission_or_share_id.encode(buf)?;
                 reason.encode(buf)?;
             }
+            Event::WorkPackageSubmission { builder, bundle, .. } => {
+                builder.encode(buf)?;
+                bundle.encode(buf)?;
+            }
+            Event::WorkPackageBeingShared { primary, .. } => {
+                primary.encode(buf)?;
+            }
+            Event::DuplicateWorkPackage {
+                submission_or_share_id,
+                core,
+                hash,
+                ..
+            } => {
+                submission_or_share_id.encode(buf)?;
+                core.encode(buf)?;
+                hash.encode(buf)?;
+            }
+            Event::ExtrinsicDataReceived {
+                submission_or_share_id,
+                ..
+            } => {
+                submission_or_share_id.encode(buf)?;
+            }
+            Event::ImportsReceived {
+                submission_or_share_id,
+                ..
+            } => {
+                submission_or_share_id.encode(buf)?;
+            }
+            Event::SharingWorkPackage {
+                submission_id, secondary, ..
+            } => {
+                submission_id.encode(buf)?;
+                secondary.encode(buf)?;
+            }
+            Event::WorkPackageSharingFailed {
+                submission_id,
+                secondary,
+                reason,
+                ..
+            } => {
+                submission_id.encode(buf)?;
+                secondary.encode(buf)?;
+                reason.encode(buf)?;
+            }
+            Event::BundleSent {
+                submission_id, secondary, ..
+            } => {
+                submission_id.encode(buf)?;
+                secondary.encode(buf)?;
+            }
+            Event::WorkReportSignatureSent { share_id, .. } => {
+                share_id.encode(buf)?;
+            }
+            Event::WorkReportSignatureReceived {
+                submission_id, secondary, ..
+            } => {
+                submission_id.encode(buf)?;
+                secondary.encode(buf)?;
+            }
             // Guarantee sending (106-108)
             Event::SendingGuarantee {
                 built_id,
@@ -1867,8 +1927,8 @@ impl Encode for Event {
                 submission_id.encode(buf)?;
                 assurer.encode(buf)?;
                 proofs.encode(buf)?;
-                // BoundedVec<(u16, u16)> — encode as length-prefixed pairs
-                (shards.len() as u32).encode(buf)?;
+                // BoundedVec<(u16, u16)> — LEB128 length prefix then pairs
+                encode_variable_length(shards.len() as u64, buf)?;
                 for (seg_id, shard_idx) in shards.iter() {
                     seg_id.encode(buf)?;
                     shard_idx.encode(buf)?;
@@ -2045,9 +2105,6 @@ impl Encode for Event {
                 length.encode(buf)?;
                 (*reason as u8).encode(buf)?;
             }
-            _ => {
-                todo!("Event::Encode not implemented for {:?}", self.event_type())
-            }
         }
         Ok(())
     }
@@ -2106,6 +2163,16 @@ impl Encode for Event {
             Event::WorkReportBuilt { outline, .. } => 8 + outline.encoded_size(),
             Event::GuaranteesDistributed { .. } => 8, // submission_id only
             Event::WorkPackageFailed { reason, .. } => 8 + reason.encoded_size(),
+            Event::WorkPackageSubmission { .. } => 32 + 1, // builder + bundle
+            Event::WorkPackageBeingShared { .. } => 32,     // primary
+            Event::DuplicateWorkPackage { .. } => 8 + 2 + 32, // submission_or_share_id + core + hash
+            Event::ExtrinsicDataReceived { .. } => 8,       // submission_or_share_id
+            Event::ImportsReceived { .. } => 8,             // submission_or_share_id
+            Event::SharingWorkPackage { .. } => 8 + 32,     // submission_id + secondary
+            Event::WorkPackageSharingFailed { reason, .. } => 8 + 32 + reason.encoded_size(),
+            Event::BundleSent { .. } => 8 + 32,             // submission_id + secondary
+            Event::WorkReportSignatureSent { .. } => 8,     // share_id
+            Event::WorkReportSignatureReceived { .. } => 8 + 32, // submission_id + secondary
             // Guarantee sending (106-108)
             Event::SendingGuarantee { .. } => 8 + 32, // built_id + recipient
             Event::GuaranteeSendFailed { reason, .. } => 8 + reason.encoded_size(),
@@ -2150,7 +2217,9 @@ impl Encode for Event {
             Event::BundleTransferred { .. } => 8,
             // Segment fetching (162-178) — SegmentsRootMapped handled elsewhere
             Event::SegmentsRootMapped { .. } => 8 + 32 + 32, // submission_id + segments_root + erasure_root
-            Event::SendingSegmentShardRequest { shards, .. } => 8 + 32 + 1 + 4 + shards.len() * 4, // len prefix + (u16,u16) pairs
+            Event::SendingSegmentShardRequest { shards, .. } => {
+                8 + 32 + 1 + variable_length_size(shards.len() as u64) + shards.len() * 4 // proofs + len + pairs
+            }
             Event::ReceivingSegmentShardRequest { .. } => 32 + 1, // sender + proofs
             Event::SegmentShardRequestFailed { reason, .. } => 8 + reason.encoded_size(),
             Event::SegmentShardRequestSent { .. } => 8,
@@ -2180,10 +2249,6 @@ impl Encode for Event {
             Event::PreimageRequestReceived { .. } => 8 + 32, // request_id + hash
             Event::PreimageTransferred { .. } => 8 + 4,      // request_id + length
             Event::PreimageDiscarded { .. } => 32 + 4 + 1,   // hash + length + reason
-            _ => todo!(
-                "Event::encoded_size not implemented for {:?}",
-                self.event_type()
-            ),
         };
 
         base_size + specific_size

--- a/src/events.rs
+++ b/src/events.rs
@@ -1927,7 +1927,7 @@ impl Encode for Event {
                 submission_id.encode(buf)?;
                 assurer.encode(buf)?;
                 proofs.encode(buf)?;
-                // BoundedVec<(u16, u16)> — LEB128 length prefix then pairs
+                // BoundedVec<(u16, u16)> — natural-number length prefix then pairs
                 encode_variable_length(shards.len() as u64, buf)?;
                 for (seg_id, shard_idx) in shards.iter() {
                     seg_id.encode(buf)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -657,15 +657,6 @@ impl Encode for AvailabilityStatement {
     }
 }
 
-impl crate::decoder::Decode for AvailabilityStatement {
-    fn decode(buf: &mut std::io::Cursor<&[u8]>) -> Result<Self, crate::decoder::DecodingError> {
-        Ok(Self {
-            anchor: crate::decoder::Decode::decode(buf)?,
-            bitfield: crate::decoder::Decode::decode(buf)?,
-        })
-    }
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ReconstructionKind {

--- a/src/types.rs
+++ b/src/types.rs
@@ -647,12 +647,13 @@ pub struct AvailabilityStatement {
 impl Encode for AvailabilityStatement {
     fn encode(&self, buf: &mut BytesMut) -> Result<(), EncodingError> {
         self.anchor.encode(buf)?;
-        self.bitfield.encode(buf)?; // Encoded with variable-length prefix
+        // JIP-3: bitfield is [u8; ceil(core_count/8)] — fixed size, no length prefix
+        buf.extend_from_slice(&self.bitfield);
         Ok(())
     }
 
     fn encoded_size(&self) -> usize {
-        32 + variable_length_size(self.bitfield.len() as u64) + self.bitfield.len()
+        32 + self.bitfield.len()
     }
 }
 

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -421,3 +421,52 @@ fn test_sending_segment_shard_request_varlen_prefix() {
     decoded.encode(&mut reencoded).unwrap();
     assert_eq!(reencoded, buf);
 }
+
+#[test]
+fn test_decode_truncated_events_no_panic() {
+    // Decoder must never panic on truncated input; it returns DecodingError instead.
+    use tart_backend::events::Event;
+
+    // Truncate a DistributingAssurance frame just before the fixed bitfield bytes:
+    // ts(8) + discriminator(1) + anchor(32) present, bitfield missing.
+    let mut buf = BytesMut::new();
+    buf.extend_from_slice(&1_700_000_000_000_000u64.to_le_bytes());
+    buf.extend_from_slice(&[126]); // DistributingAssurance discriminator
+    buf.extend_from_slice(&[0xABu8; 32]); // anchor
+    // bitfield bytes omitted
+    let mut cursor = Cursor::new(&buf[..]);
+    assert!(Event::decode_event(&mut cursor, 16).is_err());
+
+    // Unknown discriminator must produce an error, not a panic.
+    let mut buf = BytesMut::new();
+    buf.extend_from_slice(&1_700_000_000_000_000u64.to_le_bytes());
+    buf.extend_from_slice(&[200]);
+    let mut cursor = Cursor::new(&buf[..]);
+    assert!(Event::decode_event(&mut cursor, 16).is_err());
+}
+
+#[test]
+fn test_encode_no_todo_variants() {
+    // Every event variant must have an Encode arm — no todo!() panics remain.
+    use tart_backend::events::Event;
+    use tart_backend::types::BoundedString;
+
+    let ts = 1_700_000_000_000_000;
+    let events = vec![
+        Event::WorkPackageSubmission { timestamp: ts, builder: [0x11u8; 32], bundle: true },
+        Event::WorkPackageBeingShared { timestamp: ts, primary: [0x22u8; 32] },
+        Event::DuplicateWorkPackage { timestamp: ts, submission_or_share_id: 1, core: 2, hash: [0x33u8; 32] },
+        Event::ExtrinsicDataReceived { timestamp: ts, submission_or_share_id: 1 },
+        Event::ImportsReceived { timestamp: ts, submission_or_share_id: 1 },
+        Event::SharingWorkPackage { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32] },
+        Event::WorkPackageSharingFailed { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32], reason: BoundedString::new("x").unwrap() },
+        Event::BundleSent { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32] },
+        Event::WorkReportSignatureSent { timestamp: ts, share_id: 1 },
+        Event::WorkReportSignatureReceived { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32] },
+    ];
+    for event in events {
+        let mut buf = BytesMut::new();
+        event.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), event.encoded_size());
+    }
+}

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -359,3 +359,65 @@ fn test_message_frame_size_limits() {
     // This should fail due to size limit check (>10MB)
     assert!(decode_message_frame(&buf).is_err());
 }
+
+#[test]
+fn test_distributing_assurance_bitfield_fixed_no_prefix() {
+    // JIP-3: AvailabilityStatement bitfield is [u8; ceil(core_count/8)], fixed-size with NO
+    // length prefix. The decoder reads exactly ceil(core_count/8) bytes after the anchor.
+    use tart_backend::events::Event;
+    use tart_backend::types::AvailabilityStatement;
+
+    let core_count = 16u16; // ceil(16/8) = 2 bytes
+    let anchor = [0xABu8; 32];
+    let bitfield = vec![0xFFu8; 2];
+    let event = Event::DistributingAssurance {
+        timestamp: 1_700_000_000_000_000,
+        statement: AvailabilityStatement { anchor, bitfield },
+    };
+
+    let mut buf = BytesMut::new();
+    event.encode(&mut buf).unwrap();
+
+    // content = timestamp(8) + discriminator(1) + anchor(32) + bitfield(2) = 43
+    assert_eq!(buf.len(), 43, "no length prefix expected for fixed bitfield");
+    assert_eq!(buf[41], 0xFF);
+    assert_eq!(buf[42], 0xFF);
+
+    // Decoder must consume the bitfield without a prefix and round-trip.
+    let mut cursor = Cursor::new(&buf[..]);
+    let decoded = Event::decode_event(&mut cursor, core_count).unwrap();
+    match decoded {
+        Event::DistributingAssurance { statement, .. } => {
+            assert_eq!(statement.anchor, anchor);
+            assert_eq!(statement.bitfield, vec![0xFFu8; 2]);
+        }
+        _ => panic!("wrong variant decoded"),
+    }
+    assert_eq!(cursor.position() as usize, buf.len(), "whole event consumed");
+}
+
+#[test]
+fn test_sending_segment_shard_request_varlen_prefix() {
+    // BoundedVec<(u16,u16)> shards use a LEB128 variable-length count prefix.
+    use tart_backend::events::Event;
+
+    let event = Event::SendingSegmentShardRequest {
+        timestamp: 1_700_000_000_000_000,
+        submission_id: 42,
+        assurer: [0x11u8; 32],
+        proofs: true, // bool — 1 byte, no prefix
+        shards: vec![(1u16, 2u16)], // BoundedVec<(u16,u16)> — varlen count 1 byte + 4 bytes
+    };
+
+    let mut buf = BytesMut::new();
+    event.encode(&mut buf).unwrap();
+    assert_eq!(buf.len(), event.encoded_size());
+
+    // Round-trip through the decoder.
+    let mut cursor = Cursor::new(&buf[..]);
+    let decoded = Event::decode_event(&mut cursor, 16).unwrap();
+    assert_eq!(decoded.event_type() as u8, 162); // SendingSegmentShardRequest
+    let mut reencoded = BytesMut::new();
+    decoded.encode(&mut reencoded).unwrap();
+    assert_eq!(reencoded, buf);
+}

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -444,29 +444,3 @@ fn test_decode_truncated_events_no_panic() {
     let mut cursor = Cursor::new(&buf[..]);
     assert!(Event::decode_event(&mut cursor, 16).is_err());
 }
-
-#[test]
-fn test_encode_no_todo_variants() {
-    // Every event variant must have an Encode arm — no todo!() panics remain.
-    use tart_backend::events::Event;
-    use tart_backend::types::BoundedString;
-
-    let ts = 1_700_000_000_000_000;
-    let events = vec![
-        Event::WorkPackageSubmission { timestamp: ts, builder: [0x11u8; 32], bundle: true },
-        Event::WorkPackageBeingShared { timestamp: ts, primary: [0x22u8; 32] },
-        Event::DuplicateWorkPackage { timestamp: ts, submission_or_share_id: 1, core: 2, hash: [0x33u8; 32] },
-        Event::ExtrinsicDataReceived { timestamp: ts, submission_or_share_id: 1 },
-        Event::ImportsReceived { timestamp: ts, submission_or_share_id: 1 },
-        Event::SharingWorkPackage { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32] },
-        Event::WorkPackageSharingFailed { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32], reason: BoundedString::new("x").unwrap() },
-        Event::BundleSent { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32] },
-        Event::WorkReportSignatureSent { timestamp: ts, share_id: 1 },
-        Event::WorkReportSignatureReceived { timestamp: ts, submission_id: 1, secondary: [0x44u8; 32] },
-    ];
-    for event in events {
-        let mut buf = BytesMut::new();
-        event.encode(&mut buf).unwrap();
-        assert_eq!(buf.len(), event.encoded_size());
-    }
-}

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -180,16 +180,18 @@ fn test_fixed_array_encoding_decoding() {
 
 #[test]
 fn test_variable_length_encoding() {
+    // Golden bytes follow the Graypaper general natural number serialization,
+    // matching what real nodes (jam-codec) put on the wire.
     let test_cases = vec![
         (0u64, vec![0]),
         (1, vec![1]),
         (127, vec![127]),
-        (128, vec![128, 1]),
-        (255, vec![255, 1]),
-        (256, vec![128, 2]),
-        (16383, vec![255, 127]),
-        (16384, vec![128, 128, 1]),
-        (99999, vec![159, 141, 6]), // Large but below 100k limit
+        (128, vec![128, 128]),
+        (255, vec![128, 255]),
+        (256, vec![129, 0]),
+        (16383, vec![191, 255]),
+        (16384, vec![192, 0, 64]),
+        (99999, vec![193, 159, 134]), // Large but below 100k limit
     ];
 
     for (value, expected) in test_cases {
@@ -398,7 +400,7 @@ fn test_distributing_assurance_bitfield_fixed_no_prefix() {
 
 #[test]
 fn test_sending_segment_shard_request_varlen_prefix() {
-    // BoundedVec<(u16,u16)> shards use a LEB128 variable-length count prefix.
+    // BoundedVec<(u16,u16)> shards use a variable-length count prefix.
     use tart_backend::events::Event;
 
     let event = Event::SendingSegmentShardRequest {

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -381,7 +381,11 @@ fn test_distributing_assurance_bitfield_fixed_no_prefix() {
     event.encode(&mut buf).unwrap();
 
     // content = timestamp(8) + discriminator(1) + anchor(32) + bitfield(2) = 43
-    assert_eq!(buf.len(), 43, "no length prefix expected for fixed bitfield");
+    assert_eq!(
+        buf.len(),
+        43,
+        "no length prefix expected for fixed bitfield"
+    );
     assert_eq!(buf[41], 0xFF);
     assert_eq!(buf[42], 0xFF);
 
@@ -395,7 +399,11 @@ fn test_distributing_assurance_bitfield_fixed_no_prefix() {
         }
         _ => panic!("wrong variant decoded"),
     }
-    assert_eq!(cursor.position() as usize, buf.len(), "whole event consumed");
+    assert_eq!(
+        cursor.position() as usize,
+        buf.len(),
+        "whole event consumed"
+    );
 }
 
 #[test]
@@ -407,7 +415,7 @@ fn test_sending_segment_shard_request_varlen_prefix() {
         timestamp: 1_700_000_000_000_000,
         submission_id: 42,
         assurer: [0x11u8; 32],
-        proofs: true, // bool — 1 byte, no prefix
+        proofs: true,               // bool — 1 byte, no prefix
         shards: vec![(1u16, 2u16)], // BoundedVec<(u16,u16)> — varlen count 1 byte + 4 bytes
     };
 
@@ -435,7 +443,7 @@ fn test_decode_truncated_events_no_panic() {
     buf.extend_from_slice(&1_700_000_000_000_000u64.to_le_bytes());
     buf.extend_from_slice(&[126]); // DistributingAssurance discriminator
     buf.extend_from_slice(&[0xABu8; 32]); // anchor
-    // bitfield bytes omitted
+                                          // bitfield bytes omitted
     let mut cursor = Cursor::new(&buf[..]);
     assert!(Event::decode_event(&mut cursor, 16).is_err());
 

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -512,9 +512,9 @@ fn test_reason_string_edge_cases() {
     let mut buf = BytesMut::new();
     reason.encode(&mut buf).unwrap();
 
-    // Length encoding for 128 should be 2 bytes: [128, 1]
+    // Graypaper natural number encoding for 128 is 2 bytes: [128, 128]
     assert_eq!(buf[0], 128);
-    assert_eq!(buf[1], 1);
+    assert_eq!(buf[1], 128);
     assert_eq!(&buf[2..], max_reason.as_bytes());
 
     // Test reason with UTF-8 characters

--- a/tests/events_tests.rs
+++ b/tests/events_tests.rs
@@ -686,54 +686,6 @@ fn test_event_encoded_size() {
             slot: 12345,
             hash: [0xAAu8; 32],
         },
-        Event::WorkPackageSubmission {
-            timestamp: get_test_timestamp(),
-            builder: [0x11u8; 32],
-            bundle: true,
-        },
-        Event::WorkPackageBeingShared {
-            timestamp: get_test_timestamp(),
-            primary: [0x22u8; 32],
-        },
-        Event::DuplicateWorkPackage {
-            timestamp: get_test_timestamp(),
-            submission_or_share_id: 42,
-            core: 7,
-            hash: [0x33u8; 32],
-        },
-        Event::ExtrinsicDataReceived {
-            timestamp: get_test_timestamp(),
-            submission_or_share_id: 42,
-        },
-        Event::ImportsReceived {
-            timestamp: get_test_timestamp(),
-            submission_or_share_id: 42,
-        },
-        Event::SharingWorkPackage {
-            timestamp: get_test_timestamp(),
-            submission_id: 42,
-            secondary: [0x44u8; 32],
-        },
-        Event::WorkPackageSharingFailed {
-            timestamp: get_test_timestamp(),
-            submission_id: 42,
-            secondary: [0x44u8; 32],
-            reason: BoundedString::new("timeout").unwrap(),
-        },
-        Event::BundleSent {
-            timestamp: get_test_timestamp(),
-            submission_id: 42,
-            secondary: [0x44u8; 32],
-        },
-        Event::WorkReportSignatureSent {
-            timestamp: get_test_timestamp(),
-            share_id: 42,
-        },
-        Event::WorkReportSignatureReceived {
-            timestamp: get_test_timestamp(),
-            submission_id: 42,
-            secondary: [0x44u8; 32],
-        },
     ];
 
     for event in events {
@@ -800,6 +752,7 @@ fn test_work_package_variants_round_trip() {
     for event in events {
         let mut buf = BytesMut::new();
         event.encode(&mut buf).unwrap();
+        assert_eq!(buf.len(), event.encoded_size());
         let mut cursor = Cursor::new(&buf[..]);
         let decoded = Event::decode_event(&mut cursor, 16).unwrap();
         assert_eq!(decoded.event_type() as u8, event.event_type() as u8);

--- a/tests/events_tests.rs
+++ b/tests/events_tests.rs
@@ -686,12 +686,127 @@ fn test_event_encoded_size() {
             slot: 12345,
             hash: [0xAAu8; 32],
         },
+        Event::WorkPackageSubmission {
+            timestamp: get_test_timestamp(),
+            builder: [0x11u8; 32],
+            bundle: true,
+        },
+        Event::WorkPackageBeingShared {
+            timestamp: get_test_timestamp(),
+            primary: [0x22u8; 32],
+        },
+        Event::DuplicateWorkPackage {
+            timestamp: get_test_timestamp(),
+            submission_or_share_id: 42,
+            core: 7,
+            hash: [0x33u8; 32],
+        },
+        Event::ExtrinsicDataReceived {
+            timestamp: get_test_timestamp(),
+            submission_or_share_id: 42,
+        },
+        Event::ImportsReceived {
+            timestamp: get_test_timestamp(),
+            submission_or_share_id: 42,
+        },
+        Event::SharingWorkPackage {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+        },
+        Event::WorkPackageSharingFailed {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+            reason: BoundedString::new("timeout").unwrap(),
+        },
+        Event::BundleSent {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+        },
+        Event::WorkReportSignatureSent {
+            timestamp: get_test_timestamp(),
+            share_id: 42,
+        },
+        Event::WorkReportSignatureReceived {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+        },
     ];
 
     for event in events {
         let mut buf = BytesMut::new();
         event.encode(&mut buf).unwrap();
         assert_eq!(buf.len(), event.encoded_size());
+    }
+}
+
+#[test]
+fn test_work_package_variants_round_trip() {
+    // Each of the 10 formerly-todo variants must round-trip through the decoder
+    let events = vec![
+        Event::WorkPackageSubmission {
+            timestamp: get_test_timestamp(),
+            builder: [0x11u8; 32],
+            bundle: true,
+        },
+        Event::WorkPackageBeingShared {
+            timestamp: get_test_timestamp(),
+            primary: [0x22u8; 32],
+        },
+        Event::DuplicateWorkPackage {
+            timestamp: get_test_timestamp(),
+            submission_or_share_id: 42,
+            core: 7,
+            hash: [0x33u8; 32],
+        },
+        Event::ExtrinsicDataReceived {
+            timestamp: get_test_timestamp(),
+            submission_or_share_id: 42,
+        },
+        Event::ImportsReceived {
+            timestamp: get_test_timestamp(),
+            submission_or_share_id: 42,
+        },
+        Event::SharingWorkPackage {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+        },
+        Event::WorkPackageSharingFailed {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+            reason: BoundedString::new("timeout").unwrap(),
+        },
+        Event::BundleSent {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+        },
+        Event::WorkReportSignatureSent {
+            timestamp: get_test_timestamp(),
+            share_id: 42,
+        },
+        Event::WorkReportSignatureReceived {
+            timestamp: get_test_timestamp(),
+            submission_id: 42,
+            secondary: [0x44u8; 32],
+        },
+    ];
+
+    for event in events {
+        let mut buf = BytesMut::new();
+        event.encode(&mut buf).unwrap();
+        let mut cursor = Cursor::new(&buf[..]);
+        let decoded = Event::decode_event(&mut cursor, 16).unwrap();
+        assert_eq!(decoded.event_type() as u8, event.event_type() as u8);
+        // Re-encoding the decoded event must reproduce the original bytes
+        let mut reencoded = BytesMut::new();
+        decoded.encode(&mut reencoded).unwrap();
+        assert_eq!(reencoded, buf, "round-trip mismatch for {:?}", event.event_type());
     }
 }
 

--- a/tests/events_tests.rs
+++ b/tests/events_tests.rs
@@ -759,7 +759,12 @@ fn test_work_package_variants_round_trip() {
         // Re-encoding the decoded event must reproduce the original bytes
         let mut reencoded = BytesMut::new();
         decoded.encode(&mut reencoded).unwrap();
-        assert_eq!(reencoded, buf, "round-trip mismatch for {:?}", event.event_type());
+        assert_eq!(
+            reencoded,
+            buf,
+            "round-trip mismatch for {:?}",
+            event.event_type()
+        );
     }
 }
 


### PR DESCRIPTION
The test harness pretends to be a JAM node, but its event encoder didn't match the real JIP-3 wire format (wrong bitfield and length encodings, and 10 event types just panicked). This fixes the encoder so tests send real protocol bytes, and adds tests that check the byte layout against the spec.