### PR TITLE
Add custom retention procedure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           DATABASE_URL: postgres://tart:tart_password@localhost:5432/tart_test
           TEST_DATABASE_URL: postgres://tart:tart_password@localhost:5432/tart_test
           RUST_LOG: info
-        run: cargo test --test api_tests --test ws_tests --test integration_tests --test optimized_server_tests -- --test-threads=1
+        run: cargo test --test api_tests --test ws_tests --test integration_tests --test optimized_server_tests --test retention_tests -- --test-threads=1
 
   build-and-bench:
     name: Build & Benchmark

--- a/migrations/008_incremental_retention.sql
+++ b/migrations/008_incremental_retention.sql
@@ -1,0 +1,117 @@
+-- Incremental, self-healing retention for the raw events hypertable.
+--
+-- The built-in retention policy is a single transaction with 5-minute time
+-- budget and "all-or-nothing" approach. During an event storm, starting from
+-- the moment when it cannot drop all the stale events, it never succeeds and
+-- never self-heals, constantly exhausting the budget and rolling back the
+-- transaction.
+--
+-- This job drops chunks one at a time, oldest first, committing after each
+-- drop. Lock-contended / deadlocked chunks are skipped and retried next run.
+--
+-- Limitation: this does not work together with chunk compression, so the
+-- compression job must be disabled.
+
+CREATE OR REPLACE PROCEDURE tart_incremental_retention(job_id INT, config JSONB)
+LANGUAGE plpgsql
+AS $proc$
+DECLARE
+    ht         TEXT;
+    ht_schema  TEXT;
+    drop_after INTERVAL;
+    lock_wait  TEXT;
+    budget     INTERVAL;
+    started_at TIMESTAMPTZ := clock_timestamp();
+    cutoff     TIMESTAMPTZ;
+    total      BIGINT;
+    chunk      REGCLASS;
+    dropped    BIGINT := 0;
+    skipped    BIGINT := 0;
+BEGIN
+    ht         := config ->> 'hypertable';
+    ht_schema  := COALESCE(config ->> 'hypertable_schema', 'public');
+    drop_after := (config ->> 'drop_after')::INTERVAL;
+    lock_wait  := COALESCE(config ->> 'lock_timeout', '2s');
+    budget     := COALESCE((config ->> 'max_runtime')::INTERVAL, INTERVAL '4 minutes');
+
+    IF ht IS NULL OR drop_after IS NULL THEN
+        RAISE EXCEPTION 'tart_incremental_retention: config must provide "hypertable" and "drop_after", got %', config;
+    END IF;
+    IF NOT EXISTS (
+        SELECT FROM timescaledb_information.hypertables
+        WHERE hypertable_schema = ht_schema AND hypertable_name = ht
+    ) THEN
+        RAISE EXCEPTION 'tart_incremental_retention: %.% is not a hypertable', ht_schema, ht;
+    END IF;
+
+    -- Stable cutoff for the whole run: chunks becoming eligible mid-run wait
+    -- for the next run instead of turning the loop into a moving target.
+    cutoff := started_at - drop_after;
+
+    SELECT count(*) INTO total
+    FROM timescaledb_information.chunks
+    WHERE hypertable_schema = ht_schema
+      AND hypertable_name = ht
+      AND range_end <= cutoff;
+
+    -- Oldest first, so under contention the backlog still shrinks from the
+    -- tail. The chunk list is snapshotted when the loop opens (the cursor
+    -- becomes holdable at the first COMMIT); chunks created later are not
+    -- seen, which is fine — they cannot be eligible under this run's cutoff.
+    FOR chunk IN
+        SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS
+        FROM timescaledb_information.chunks
+        WHERE hypertable_schema = ht_schema
+          AND hypertable_name = ht
+          AND range_end <= cutoff
+        ORDER BY range_end, chunk_name
+    LOOP
+        EXIT WHEN clock_timestamp() - started_at >= budget;
+
+        -- Transaction-local, so it must be re-armed after every COMMIT.
+        PERFORM set_config('lock_timeout', lock_wait, true);
+        BEGIN
+            EXECUTE format('DROP TABLE %s', chunk);
+            dropped := dropped + 1;
+        EXCEPTION
+            WHEN lock_not_available OR deadlock_detected THEN
+                skipped := skipped + 1;
+                RAISE LOG 'tart_incremental_retention(%.%): skipped % (%: %)',
+                    ht_schema, ht, chunk, SQLSTATE, SQLERRM;
+            WHEN undefined_table THEN
+                -- Dropped concurrently (e.g. manual intervention) — still progress.
+                dropped := dropped + 1;
+        END;
+        COMMIT;
+    END LOOP;
+
+    RAISE LOG 'tart_incremental_retention(%.%): dropped %, skipped %, left % of % eligible chunk(s) in %',
+        ht_schema, ht, dropped, skipped, total - dropped - skipped, total,
+        clock_timestamp() - started_at;
+END
+$proc$;
+
+SELECT remove_compression_policy('ingested_raw_events', if_exists => TRUE);
+
+DO $block$
+BEGIN
+    IF EXISTS (
+        SELECT FROM timescaledb_information.hypertables
+        WHERE hypertable_schema = 'public'
+          AND hypertable_name = 'ingested_raw_events'
+          AND compression_enabled
+    ) THEN
+        ALTER TABLE public.ingested_raw_events SET (timescaledb.compress = false);
+    END IF;
+END
+$block$;
+
+-- Swap the built-in policy for the incremental job.
+SELECT remove_retention_policy('ingested_raw_events', if_exists => TRUE);
+
+SELECT add_job(
+    'tart_incremental_retention',
+    schedule_interval => INTERVAL '5 minutes',
+    config => '{"hypertable": "ingested_raw_events", "drop_after": "1 hour", "lock_timeout": "2s", "max_runtime": "4 minutes"}',
+    fixed_schedule => false
+);

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,11 +16,12 @@ These tests run in parallel and don't require external services:
 
 ### Integration Tests (Require PostgreSQL)
 These tests use a real PostgreSQL database and MUST run serially:
-- `api_tests.rs` - REST API endpoints (10 tests)
+- `api_tests.rs` - REST API endpoints (16 tests)
 - `integration_tests.rs` - End-to-end telemetry flow (8 tests)
-- `optimized_server_tests.rs` - Performance and concurrency (6 tests)
+- `optimized_server_tests.rs` - Performance and concurrency (5 tests)
+- `retention_tests.rs` - Incremental raw-events retention job (2 tests)
 
-**Total: 24 integration tests**
+**Total: 31 integration tests**
 
 ## Running Tests Locally
 
@@ -42,7 +43,7 @@ cargo sqlx migrate run
 # _sqlx_migrations ledger doesn't match the squashed migration set.
 
 # Run integration tests SERIALLY
-cargo test --test api_tests --test integration_tests --test optimized_server_tests -- --test-threads=1
+cargo test --test api_tests --test integration_tests --test optimized_server_tests --test retention_tests -- --test-threads=1
 ```
 
 ## Why Tests Must Run Serially (`--test-threads=1`)
@@ -229,7 +230,7 @@ GitHub Actions workflow (`.github/workflows/ci.yml`):
 cargo test --lib --test types_tests --test events_tests --test error_tests --test encoding_tests
 
 # Integration tests serially (safe)
-cargo test --test api_tests --test integration_tests --test optimized_server_tests -- --test-threads=1
+cargo test --test api_tests --test integration_tests --test optimized_server_tests --test retention_tests -- --test-threads=1
 ```
 
 This ensures:

--- a/tests/retention_tests.rs
+++ b/tests/retention_tests.rs
@@ -1,0 +1,241 @@
+// Integration tests for the incremental raw-events retention job
+// (migrations/008_incremental_retention.sql).
+//
+// Require PostgreSQL/TimescaleDB — see tests/README.md. Run serially:
+//   cargo test --test retention_tests -- --test-threads=1
+
+mod common;
+
+use std::sync::Arc;
+use tart_backend::EventStore;
+
+/// Connect, run migrations, wipe data, and pause the scheduled retention job
+/// so tests can CALL the procedure deterministically.
+///
+/// Each test re-enables the job on success; a panicked run leaves it paused,
+/// which the next setup() simply repeats — harmless on a test database.
+async fn setup() -> (Arc<EventStore>, sqlx::PgPool) {
+    let database_url = common::test_database_url();
+
+    let store = Arc::new(
+        EventStore::new(&database_url)
+            .await
+            .expect("DB connection failed"),
+    );
+    store.cleanup_test_data().await.expect("Cleanup failed");
+
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(3)
+        .connect(&database_url)
+        .await
+        .expect("Pool connection failed");
+
+    sqlx::query(
+        "SELECT alter_job(job_id, scheduled => false) FROM timescaledb_information.jobs \
+         WHERE proc_name = 'tart_incremental_retention'",
+    )
+    .execute(&pool)
+    .await
+    .expect("Failed to pause retention job");
+
+    (store, pool)
+}
+
+async fn reenable_job(pool: &sqlx::PgPool) {
+    sqlx::query(
+        "SELECT alter_job(job_id, scheduled => true) FROM timescaledb_information.jobs \
+         WHERE proc_name = 'tart_incremental_retention'",
+    )
+    .execute(pool)
+    .await
+    .expect("Failed to re-enable retention job");
+}
+
+/// Insert `count` raw events aged `age` (an interval like '3 hours'), spread
+/// across 8 node ids so several space partitions get chunks.
+async fn insert_events(pool: &sqlx::PgPool, age: &str, count: i64, tag: &str) {
+    sqlx::query(
+        "INSERT INTO ingested_raw_events (timestamp, node_id, event_id, event_type, data) \
+         SELECT now() - $1::interval, $2 || (i % 8)::text, i, 10, '{}'::jsonb \
+         FROM generate_series(1, $3) i",
+    )
+    .bind(age)
+    .bind(tag)
+    .bind(count)
+    .execute(pool)
+    .await
+    .expect("Failed to insert test events");
+}
+
+/// Chunks of ingested_raw_events eligible for the 1-hour retention window.
+async fn eligible_chunks(pool: &sqlx::PgPool) -> Vec<String> {
+    sqlx::query_scalar(
+        "SELECT format('%I.%I', chunk_schema, chunk_name) \
+         FROM timescaledb_information.chunks \
+         WHERE hypertable_name = 'ingested_raw_events' \
+           AND range_end <= now() - interval '1 hour' \
+         ORDER BY range_end, chunk_name",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("Failed to list chunks")
+}
+
+/// CALL the retention procedure the way the scheduler would.
+/// raw_sql uses the simple query protocol, which permits the procedure's
+/// internal COMMITs (no surrounding transaction).
+async fn run_retention(pool: &sqlx::PgPool, lock_timeout: &str) {
+    let call = format!(
+        "CALL tart_incremental_retention(0, '{{\
+            \"hypertable\": \"ingested_raw_events\", \
+            \"drop_after\": \"1 hour\", \
+            \"lock_timeout\": \"{lock_timeout}\", \
+            \"max_runtime\": \"1 minute\"}}'::jsonb)"
+    );
+    sqlx::raw_sql(&call)
+        .execute(pool)
+        .await
+        .expect("CALL tart_incremental_retention failed");
+}
+
+#[tokio::test]
+async fn incremental_retention_replaces_policy_and_drops_only_old_chunks() {
+    let (_store, pool) = setup().await;
+
+    // Migration 008 must have removed the built-in policy...
+    let builtin: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM timescaledb_information.jobs \
+         WHERE proc_name = 'policy_retention' AND hypertable_name = 'ingested_raw_events'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(builtin, 0, "built-in retention policy should be removed");
+
+    // Compression is unnecessary with a one-hour retention window. Migration
+    // 008 must remove the old policy and disable the hypertable setting.
+    let compression_jobs: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM timescaledb_information.jobs \
+         WHERE proc_name = 'policy_compression' \
+           AND hypertable_name = 'ingested_raw_events'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(compression_jobs, 0, "compression policy should be removed");
+
+    let compression_enabled: bool = sqlx::query_scalar(
+        "SELECT compression_enabled FROM timescaledb_information.hypertables \
+         WHERE hypertable_schema = 'public' \
+           AND hypertable_name = 'ingested_raw_events'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        !compression_enabled,
+        "compression should be disabled on the raw-events hypertable"
+    );
+
+    // The migration must also register the custom job with the same window.
+    let custom: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM timescaledb_information.jobs \
+         WHERE proc_name = 'tart_incremental_retention' \
+           AND config ->> 'hypertable' = 'ingested_raw_events' \
+           AND config ->> 'drop_after' = '1 hour'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(custom, 1, "incremental retention job should be registered");
+
+    insert_events(&pool, "3 hours", 800, "ret-old-").await;
+    insert_events(&pool, "0 seconds", 800, "ret-new-").await;
+
+    assert!(
+        !eligible_chunks(&pool).await.is_empty(),
+        "old inserts should create retention-eligible chunks"
+    );
+
+    run_retention(&pool, "2s").await;
+
+    assert!(
+        eligible_chunks(&pool).await.is_empty(),
+        "all eligible chunks should be dropped"
+    );
+    let old_rows: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM ingested_raw_events WHERE timestamp <= now() - interval '1 hour'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        old_rows, 0,
+        "no rows older than the retention window remain"
+    );
+    let new_rows: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM ingested_raw_events WHERE node_id LIKE 'ret-new-%'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(new_rows, 800, "fresh rows must be untouched");
+
+    reenable_job(&pool).await;
+}
+
+#[tokio::test]
+async fn incremental_retention_skips_locked_chunk_and_recovers() {
+    let (_store, pool) = setup().await;
+
+    // Two distinct time slices → guaranteed distinct chunks, oldest tried first.
+    insert_events(&pool, "5 hours", 400, "ret-lock-").await;
+    insert_events(&pool, "3 hours", 400, "ret-old-").await;
+
+    let before = eligible_chunks(&pool).await;
+    assert!(
+        before.len() > 1,
+        "need several eligible chunks, got {before:?}"
+    );
+
+    // Hold an AccessShareLock on one 5h-old chunk in an open transaction,
+    // simulating a long-running browsing query.
+    let locked_chunk: String = sqlx::query_scalar(
+        "SELECT format('%I.%I', chunk_schema, chunk_name) \
+         FROM timescaledb_information.chunks \
+         WHERE hypertable_name = 'ingested_raw_events' \
+           AND range_end <= now() - interval '4 hours' \
+         ORDER BY range_end, chunk_name LIMIT 1",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("expected a 5h-old chunk");
+
+    let mut tx = pool.begin().await.unwrap();
+    sqlx::query(&format!("SELECT count(*) FROM {locked_chunk}"))
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+
+    // Short lock_timeout keeps the test fast; the job must skip the locked
+    // chunk, drop everything else, and complete without error.
+    run_retention(&pool, "500ms").await;
+
+    let remaining = eligible_chunks(&pool).await;
+    assert_eq!(
+        remaining,
+        vec![locked_chunk.clone()],
+        "only the locked chunk should survive"
+    );
+
+    // Lock released ("the storm is over") → the next run finishes the job.
+    tx.rollback().await.unwrap();
+    run_retention(&pool, "500ms").await;
+
+    assert!(
+        eligible_chunks(&pool).await.is_empty(),
+        "retention should self-heal once the lock is gone"
+    );
+
+    reenable_job(&pool).await;
+}


### PR DESCRIPTION
Partially fixes #29.

Add a custom retention procedure devoid of drawbacks of the stock one:
* It doesn't rollback the entire retention job if the time budget expires, and commits chunk-by-chunk;
* It accounts for its own time budget, not relying on the scheduler to kill the worker, and thus avoids triggering, during normal function, the backoff logic that indeed makes things worse;

The migration also removes the compression policy we don't use, which contributed to the DB stall during the event storm.